### PR TITLE
Pagination Support Added for Users, Collections, Egress, and Providers

### DIFF
--- a/src/api/apiKeys.js
+++ b/src/api/apiKeys.js
@@ -4,8 +4,8 @@ import apiClient from './apiClient';
  * Lists all API keys visible to the current user.
  * The backend filters keys based on the user's role and active ngroup.
  */
-export const getApiKeys = () => {
-  return apiClient.get('/api-keys/');
+export const getApiKeys = ({page = 1, pageSize = 10}) => {
+  return apiClient.get(`/api-keys/?page=${page}&page_size=${pageSize}`);
 };
 
 /**

--- a/src/api/collectionApi.js
+++ b/src/api/collectionApi.js
@@ -10,7 +10,7 @@ import { config } from '../config'; // Needed for legacy functions
 /**
  * Retrieves all collections for the user's currently active ngroup.
  */
-export const listCollections = (page = 1, pageSize = 10) => {
+export const listCollections = (page = 1, pageSize = 50) => {
     return apiClient.get(`/collections/?page=${page}&page_size=${pageSize}`);
 };
 

--- a/src/api/cueUser.js
+++ b/src/api/cueUser.js
@@ -7,7 +7,7 @@ import apiClient from './apiClient';
  * Lists all Cueusers for the currently active ngroup.
  * The backend filters users based on the X-Active-Ngroup-Id header.
  */
-export const listCueusers = (page = 1, pageSize = 10) => {
+export const listCueusers = (page = 1, pageSize = 50) => {
     return apiClient.get(`/cueusers/?page=${page}&page_size=${pageSize}`);
 };
 

--- a/src/api/egressAPI.js
+++ b/src/api/egressAPI.js
@@ -6,7 +6,7 @@ import apiClient from './apiClient';
  * Retrieves all egress records for the user's currently active ngroup.
  * The backend filters based on the X-Active-Ngroup-Id header sent by the apiClient.
  */
-export const listEgresses = (page = 1, pageSize = 10) => {
+export const listEgresses = (page = 1, pageSize = 50) => {
     return apiClient.get(`/egress/?page=${page}&page_size=${pageSize}`);
 };
 

--- a/src/api/providerApi.js
+++ b/src/api/providerApi.js
@@ -17,7 +17,7 @@ export const getProvidersForApplication = (ngroupId) => {
  * This function now relies on the apiClient to automatically add the 
  * X-Active-Ngroup-Id header instead of using a query parameter.
  */
-export const listProviders = (page = 1, pageSize = 10) => {
+export const listProviders = (page = 1, pageSize = 50) => {
     return apiClient.get(`/providers/?page=${page}&page_size=${pageSize}`);
 };
 

--- a/src/api/providerApi.js
+++ b/src/api/providerApi.js
@@ -21,6 +21,10 @@ export const listProviders = (page = 1, pageSize = 50) => {
     return apiClient.get(`/providers/?page=${page}&page_size=${pageSize}`);
 };
 
+export const filterProviders = (page = 1, pageSize = 50, can_upload ) => {
+    return apiClient.get(`/providers/?page=${page}&page_size=${pageSize}&can_upload=${can_upload}`);
+};
+
 /**
  * Retrieves a single provider by its ID. Requires 'view_provider' privilege.
  * @param {string} providerId - The UUID of the provider.

--- a/src/app/reducers/dataCacheSlice.js
+++ b/src/app/reducers/dataCacheSlice.js
@@ -71,11 +71,11 @@ export const fetchEgresses = createAsyncThunk(
 // --- Initial State ---
 
 const initialState = {
-  providers: { data: [], status: 'idle', page: 1, pageSize: 10, total: 0 }, // status: 'idle' | 'loading' | 'succeeded' | 'failed'
-  users: { data: [], status: 'idle', page: 1, pageSize: 10, total: 0},
-  collections: { data: [], page: 1, pageSize: 10, total: 0, status: 'idle' },
+  providers: { data: [], status: 'idle', page: 1, pageSize: 50, total: 0 }, // status: 'idle' | 'loading' | 'succeeded' | 'failed'
+  users: { data: [], status: 'idle', page: 1, pageSize: 50, total: 0},
+  collections: { data: [], page: 1, pageSize: 50, total: 0, status: 'idle' },
   roles: { data: [], status: 'idle' },
-  egresses: { data: [], status: 'idle', page: 1, pageSize: 10, total: 0},
+  egresses: { data: [], status: 'idle', page: 1, pageSize: 50, total: 0},
   error: null,
 };
 
@@ -87,11 +87,11 @@ const dataCacheSlice = createSlice({
   reducers: {
     // Action to reset the cache, e.g., when the activeNgroupId changes
     resetCache: (state) => {
-      state.providers = { data: [], status: 'idle', page: 1, pageSize: 10, total: 0};
-      state.users = { data: [], status: 'idle', page: 1, pageSize: 10, total: 0};
-      state.collections = { data: [], status: 'idle', page: 1, pageSize: 10, total: 0};
+      state.providers = { data: [], status: 'idle', page: 1, pageSize: 50, total: 0};
+      state.users = { data: [], status: 'idle', page: 1, pageSize: 50, total: 0};
+      state.collections = { data: [], status: 'idle', page: 1, pageSize: 50, total: 0};
       state.roles = { data: [], status: 'idle' };
-      state.egresses = { data: [], status: 'idle', page: 1, pageSize: 10, total: 0};
+      state.egresses = { data: [], status: 'idle', page: 1, pageSize: 50, total: 0};
       state.error = null;
     },
   },

--- a/src/app/reducers/dataCacheSlice.js
+++ b/src/app/reducers/dataCacheSlice.js
@@ -134,8 +134,8 @@ const dataCacheSlice = createSlice({
         state[entity].page = page;
         state[entity].pageSize = pageSize;
         state[entity].total = action.payload.total;
-        state[entity].cacheStart = (page - 1) * pageSize;
-        state[entity].cacheSize = items.length;
+        state[entity].cacheStart = action.payload.cacheStart;
+        state[entity].cacheSize = action.payload.cacheSize;
     };
 
 

--- a/src/app/reducers/dataCacheSlice.js
+++ b/src/app/reducers/dataCacheSlice.js
@@ -40,12 +40,14 @@ export const fetchUsers = createAsyncThunk(
 
 export const fetchCollections = createAsyncThunk(
   'dataCache/fetchCollections', async ({ page, pageSize }, { rejectWithValue }) => {
-     try {
-      const response = await collectionApi.listCollections(page, pageSize);
+     try { 
+      const response = await collectionApi.listCollections(page, pageSize); 
+      response.cacheStart = (page - 1) * pageSize;
+      response.cacheSize = pageSize
       return response; // response = { collections, page, page_size, total }
-    }
-    catch (error) {
-      return rejectWithValue(parseApiError(error)); }
+    } 
+    catch (error) { 
+      return rejectWithValue(parseApiError(error)); } 
   } );
 
 export const fetchRoles = createAsyncThunk(

--- a/src/app/reducers/dataCacheSlice.js
+++ b/src/app/reducers/dataCacheSlice.js
@@ -61,7 +61,9 @@ export const fetchEgresses = createAsyncThunk(
   async ({ page, pageSize }, { rejectWithValue }) => {
     try {
       const response = await egressApi.listEgresses(page, pageSize);
-      return response || [];
+      response.cacheStart = (page - 1) * pageSize;
+      response.cacheSize = pageSize
+      return response;
     } catch (error) {
       return rejectWithValue(parseApiError(error));
     }
@@ -71,11 +73,11 @@ export const fetchEgresses = createAsyncThunk(
 // --- Initial State ---
 
 const initialState = {
-  providers: { data: [], status: 'idle', page: 1, pageSize: 50, total: 0 }, // status: 'idle' | 'loading' | 'succeeded' | 'failed'
-  users: { data: [], status: 'idle', page: 1, pageSize: 50, total: 0},
-  collections: { data: [], page: 1, pageSize: 50, total: 0, status: 'idle' },
+  providers: { data: [], status: 'idle', page: 1, pageSize: 50, total: 0, cacheStart: 0, cacheSize: 50}, // status: 'idle' | 'loading' | 'succeeded' | 'failed'
+  users: { data: [], status: 'idle', page: 1, pageSize: 50, total: 0, cacheStart: 0, cacheSize: 50},
+  collections: { data: [], page: 1, pageSize: 50, total: 0, status: 'idle', cacheStart: 0, cacheSize: 50},
   roles: { data: [], status: 'idle' },
-  egresses: { data: [], status: 'idle', page: 1, pageSize: 50, total: 0},
+  egresses: { data: [], status: 'idle', page: 1, pageSize: 50, total: 0, cacheStart: 0, cacheSize: 50},
   error: null,
 };
 
@@ -87,11 +89,11 @@ const dataCacheSlice = createSlice({
   reducers: {
     // Action to reset the cache, e.g., when the activeNgroupId changes
     resetCache: (state) => {
-      state.providers = { data: [], status: 'idle', page: 1, pageSize: 50, total: 0};
-      state.users = { data: [], status: 'idle', page: 1, pageSize: 50, total: 0};
-      state.collections = { data: [], status: 'idle', page: 1, pageSize: 50, total: 0};
+      state.providers = { data: [], status: 'idle', page: 1, pageSize: 50, total: 0, cacheStart: 0, cacheSize: 50};
+      state.users = { data: [], status: 'idle', page: 1, pageSize: 50, total: 0, cacheStart: 0, cacheSize: 50};
+      state.collections = { data: [], status: 'idle', page: 1, pageSize: 50, total: 0, cacheStart: 0, cacheSize: 50};
       state.roles = { data: [], status: 'idle' };
-      state.egresses = { data: [], status: 'idle', page: 1, pageSize: 50, total: 0};
+      state.egresses = { data: [], status: 'idle', page: 1, pageSize: 50, total: 0, cacheStart: 0, cacheSize: 50};
       state.error = null;
     },
   },
@@ -115,13 +117,21 @@ const dataCacheSlice = createSlice({
     };
 
     const handlePaginationFulfilled = (state, action) => {
-      const entity = action.type.split('/')[1].split('fetch')[1].toLowerCase();
-      state[entity].status = 'succeeded';
-      state[entity].data = action.payload[entity];
-      state[entity].page = action.payload.page;
-      state[entity].pageSize = action.payload.page_size;
-      state[entity].total = action.payload.total;
-    }
+        const entity = action.type.split('/')[1].split('fetch')[1].toLowerCase();
+
+        const page = action.payload.page;
+        const pageSize = action.payload.page_size;
+        const items = action.payload[entity];
+
+        state[entity].status = 'succeeded';
+        state[entity].data = items;
+        state[entity].page = page;
+        state[entity].pageSize = pageSize;
+        state[entity].total = action.payload.total;
+        state[entity].cacheStart = (page - 1) * pageSize;
+        state[entity].cacheSize = items.length;
+    };
+
 
     builder
       .addCase(fetchProviders.pending, handlePending)

--- a/src/app/reducers/dataCacheSlice.js
+++ b/src/app/reducers/dataCacheSlice.js
@@ -15,6 +15,8 @@ export const fetchProviders = createAsyncThunk(
   async ({ page, pageSize }, { rejectWithValue }) => {
     try {
       const response = await providerApi.listProviders(page, pageSize);
+      response.cacheStart = (page - 1) * pageSize;
+      response.cacheSize = pageSize
       return response;
     } catch (error) {
       return rejectWithValue(parseApiError(error));
@@ -27,7 +29,9 @@ export const fetchUsers = createAsyncThunk(
   async ({ page, pageSize }, { rejectWithValue }) => {
     try {
       const response = await listCueusers(page, pageSize);
-      return response || [];
+      response.cacheStart = (page - 1) * pageSize;
+      response.cacheSize = pageSize
+      return response;
     } catch (error) {
       return rejectWithValue(parseApiError(error));
     }

--- a/src/app/reducers/dataCacheSlice.js
+++ b/src/app/reducers/dataCacheSlice.js
@@ -34,14 +34,14 @@ export const fetchUsers = createAsyncThunk(
   }
 );
 
-export const fetchCollections = createAsyncThunk( 
+export const fetchCollections = createAsyncThunk(
   'dataCache/fetchCollections', async ({ page, pageSize }, { rejectWithValue }) => {
-     try { 
-      const response = await collectionApi.listCollections(page, pageSize); 
-      return response; // response = { collections, page, page_size, total } 
-    } 
-    catch (error) { 
-      return rejectWithValue(parseApiError(error)); } 
+     try {
+      const response = await collectionApi.listCollections(page, pageSize);
+      return response; // response = { collections, page, page_size, total }
+    }
+    catch (error) {
+      return rejectWithValue(parseApiError(error)); }
   } );
 
 export const fetchRoles = createAsyncThunk(

--- a/src/pages/Collections.js
+++ b/src/pages/Collections.js
@@ -64,6 +64,7 @@ function Collections() {
     const [dialog, setDialog] = useState({ open: null, data: null });
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [filteredCount, setFilteredCount] = useState(0);
+    const [initialLoadComplete, setInitialLoadComplete] = useState(false);
 
     const firstSelectedStatus = useMemo(() => {
         if (selected.length === 0) return true;
@@ -81,7 +82,9 @@ function Collections() {
     // "Smart" data fetching effect that uses the cache
     useEffect(() => {
         if (activeNgroupId) {
-            if (collections.status === 'idle') dispatch(fetchCollections({ page: 1, pageSize: 50 }));
+            if (collections.status === 'idle' || (!initialLoadComplete && collections.page !== 1)) {
+                dispatch(fetchCollections({ page: 1, pageSize: 50 }));
+                setInitialLoadComplete(true);}
             if (providers.status === 'idle') dispatch(fetchProviders({ page: 1, pageSize: 50 }));
             if (egresses.status === 'idle') dispatch(fetchEgresses({ page: 1, pageSize: 50 }));
         }
@@ -168,6 +171,17 @@ function Collections() {
     useEffect(() => {
         setCurrentPage(0);
     }, [searchTerm]);
+
+    // Reset pagination when ngroup changes or when new collections load
+    useEffect(() => {
+        const maxPage = Math.floor((collections.total - 1) / rowsPerPage) || 0;
+
+        // if currentPage is invalid, reset to 0
+        if (currentPage > maxPage) {
+            setCurrentPage(0);
+        }
+    }, [activeNgroupId, collections.total]);
+
 
     const processedCollections = useMemo(() => {
         if (!collections.data || !providers.data || !egresses.data) return [];

--- a/src/pages/Collections.js
+++ b/src/pages/Collections.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import {
     Box, Card, CardContent, Typography, Button, TextField,
     Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, 
@@ -64,7 +64,8 @@ function Collections() {
     const [dialog, setDialog] = useState({ open: null, data: null });
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [filteredCount, setFilteredCount] = useState(0);
-    const [initialLoadComplete, setInitialLoadComplete] = useState(false);
+    const didMount = useRef(false);
+    const [prevPage, setPrevPage] = useState(0);
 
     const firstSelectedStatus = useMemo(() => {
         if (selected.length === 0) return true;
@@ -82,9 +83,10 @@ function Collections() {
     // "Smart" data fetching effect that uses the cache
     useEffect(() => {
         if (activeNgroupId) {
-            if (collections.status === 'idle' || (!initialLoadComplete && collections.page !== 1)) {
+            if (collections.status === 'idle' || !didMount.current) {
                 dispatch(fetchCollections({ page: 1, pageSize: 50 }));
-                setInitialLoadComplete(true);}
+                didMount.current = true;
+            }
             if (providers.status === 'idle') dispatch(fetchProviders({ page: 1, pageSize: 50 }));
             if (egresses.status === 'idle') dispatch(fetchEgresses({ page: 1, pageSize: 50 }));
         }

--- a/src/pages/Collections.js
+++ b/src/pages/Collections.js
@@ -84,8 +84,10 @@ function Collections() {
     // "Smart" data fetching effect that uses the cache
     useEffect(() => {
         if (activeNgroupId) {
-            if (collections.status === 'idle' || !didMount.current) {
-                dispatch(fetchCollections({ page: 1, pageSize: 50 }));
+            if (!didMount.current) {
+                if(collections.status === 'idle' || collections.page !== 1){
+                    dispatch(fetchCollections({ page: 1, pageSize: 50 }));
+                }
                 didMount.current = true;
             }
             if (providers.status === 'idle') dispatch(fetchProviders({ page: 1, pageSize: 50 }));

--- a/src/pages/Collections.js
+++ b/src/pages/Collections.js
@@ -66,6 +66,7 @@ function Collections() {
     const [filteredCount, setFilteredCount] = useState(0);
     const didMount = useRef(false);
     const [prevPage, setPrevPage] = useState(0);
+    const wasSearching = useRef(false);
 
     const firstSelectedStatus = useMemo(() => {
         if (selected.length === 0) return true;
@@ -171,8 +172,21 @@ function Collections() {
     }, [egresses.data]);
 
     useEffect(() => {
-        setCurrentPage(0);
-    }, [searchTerm]);
+        const isSearching = searchTerm.trim() !== "";
+
+        if (isSearching && !wasSearching.current) {
+            // Search just started — store page ONCE
+            setPrevPage(currentPage);
+            setCurrentPage(0);
+        }
+
+        if (!isSearching && wasSearching.current) {
+            // Search just ended — restore ONCE
+            setCurrentPage(prevPage);
+        }
+
+        wasSearching.current = isSearching;
+    }, [searchTerm, currentPage, prevPage]);
 
     // Reset pagination when ngroup changes or when new collections load
     useEffect(() => {
@@ -222,19 +236,16 @@ function Collections() {
         }
         
         let startIndex, endIndex;
-        // Prevent negative or out-of-range pages
-        const safePage = Math.max(
-            0,
-            Math.min(
-                currentPage,
-                Math.floor((filtered.length - 1) / rowsPerPage)  // max valid page
-            )
-        );
 
         if (searchTerm) {
-            // SCENARIO 1: SEARCHING/FILTERING
-            // List contains the *entire* locally filtered/sorted set.
-            startIndex = safePage * rowsPerPage;
+            const maxFilteredPage = Math.max(
+                0,
+                Math.floor((filtered.length - 1) / rowsPerPage)
+            );
+
+            const safeSearchPage = Math.min(currentPage, maxFilteredPage);
+
+            startIndex = safeSearchPage * rowsPerPage;
             endIndex = startIndex + rowsPerPage;
         } else {
             // SCENARIO 2: NORMAL VIEW (PAGINATING THROUGH CACHE CHUNKS)
@@ -369,8 +380,10 @@ function Collections() {
         if (!isWithinCache(newPage)) {
             const apiPageSize = 50; // chunk size
             const startIndex = newPage * rowsPerPage;
-            const apiPage = Math.floor(startIndex / apiPageSize) + 1;
-            dispatch(fetchCollections({ page: apiPage, pageSize: apiPageSize }));
+            if (!searchTerm){
+                const apiPage = Math.floor(startIndex / apiPageSize) + 1;
+                dispatch(fetchCollections({ page: apiPage, pageSize: apiPageSize }));
+            }
         }
     };
 
@@ -381,8 +394,10 @@ function Collections() {
         if (!isWithinCache(0)) {
             const apiPageSize = 50; // chunk size
             const startIndex = 0;
-            const apiPage = Math.floor(startIndex / apiPageSize) + 1;
-            dispatch(fetchCollections({ page: apiPage, pageSize: apiPageSize }));
+            if (!searchTerm) {
+                const apiPage = Math.floor(startIndex / apiPageSize) + 1;
+                dispatch(fetchCollections({ page: apiPage, pageSize: apiPageSize }));
+            }
         }
         setRowsPerPage(newSize);  // only update UI rows per page
     };

--- a/src/pages/Collections.js
+++ b/src/pages/Collections.js
@@ -48,7 +48,17 @@ function Collections() {
     // Local state for UI operations
     const [loading, setLoading] = useState(true);
     const [selected, setSelected] = useState([]);
-    const [pagination, setPagination] = useState({ page: 0, pageSize: 10 });
+    const [rowsPerPage, setRowsPerPage] = useState(10);
+    const [currentPage, setCurrentPage] = useState(0); // 0-based for MUI TablePagination
+    const pagination = {
+        page: currentPage,
+        pageSize: rowsPerPage,
+        total: collections.total ?? 0
+    };
+    const [providerLoadingPages, setProviderLoadingPages] = useState(new Set());
+    const [egressLoadingPages, setEgressLoadingPages] = useState(new Set());
+    const [mergedProviders, setMergedProviders] = useState([]);
+    const [mergedEgress, setMergedEgress] = useState([]);
     const [sorting, setSorting] = useState({ orderBy: 'short_name', order: 'asc' });
     const [searchTerm, setSearchTerm] = useState('');
     const [dialog, setDialog] = useState({ open: null, data: null });
@@ -70,9 +80,9 @@ function Collections() {
     // "Smart" data fetching effect that uses the cache
     useEffect(() => {
         if (activeNgroupId) {
-            if (collections.status === 'idle') dispatch(fetchCollections());
-            if (providers.status === 'idle') dispatch(fetchProviders());
-            if (egresses.status === 'idle') dispatch(fetchEgresses());
+            if (collections.status === 'idle') dispatch(fetchCollections({ page: 1, pageSize: 50 }));
+            if (providers.status === 'idle') dispatch(fetchProviders({ page: 1, pageSize: 50 }));
+            if (egresses.status === 'idle') dispatch(fetchEgresses({ page: 1, pageSize: 50 }));
         }
     }, [activeNgroupId, collections.status, providers.status, egresses.status, dispatch]);
 
@@ -82,17 +92,89 @@ function Collections() {
         setLoading(isLoading);
     }, [collections.status, providers.status, egresses.status]);
 
+    useEffect(() => {
+        if (!providers || !providers.data) return;
+
+        const page = providers.page;
+
+        // avoids duplicate provider calls when scrolling 
+        // Remove this page from loadingPages when it finishes
+        setProviderLoadingPages(prev => {
+            const newSet = new Set(prev);
+            newSet.delete(page);
+            return newSet;
+        });
+
+        const newPageStart = providers.cacheStart;
+        const newPageSize = providers.data.length;
+
+        setMergedProviders(prev => {
+            // First load → set directly
+            if (prev.length === 0) {
+                return providers.data;
+            }
+
+            // SCROLL DOWN (next page)
+            if (newPageStart > prev.length - newPageSize) {
+                return [...prev, ...providers.data];
+            }
+
+            // SCROLL UP (previous page)
+            if (newPageStart < 0) {
+                return [...providers.data, ...prev];
+            }
+
+            return prev; // default
+        });
+    }, [providers.data]);
+
+    useEffect(() => {
+        if (!egresses || !egresses.data) return;
+
+        const page = egresses.page;
+
+        // avoids duplicate egress calls when scrolling 
+        // Remove this page from loadingPages when it finishes
+        setEgressLoadingPages(prev => {
+            const newSet = new Set(prev);
+            newSet.delete(page);
+            return newSet;
+        });
+
+        const newPageStart = egresses.cacheStart;
+        const newPageSize = egresses.data.length;
+
+        setMergedEgress(prev => {
+            // First load → set directly
+            if (prev.length === 0) {
+                return egresses.data;
+            }
+
+            // SCROLL DOWN (next page)
+            if (newPageStart > prev.length - newPageSize) {
+                return [...prev, ...egresses.data];
+            }
+
+            // SCROLL UP (previous page)
+            if (newPageStart < 0) {
+                return [...egresses.data, ...prev];
+            }
+
+            return prev; // default
+        });
+    }, [egresses.data]);
+
+
     const processedCollections = useMemo(() => {
         if (!collections.data || !providers.data || !egresses.data) return [];
-        
-        const providerMap = new Map(providers.data.map(p => [p.id, p.short_name]));
-        const egressMap = new Map(egresses.data.map(e => [e.id, e.path]));
 
         const collectionsWithDetails = collections.data.map(collection => ({
             ...collection,
-            provider_name: providerMap.get(collection.provider_id) || 'N/A',
-            egress_path: egressMap.get(collection.egress_id) || 'N/A',
+            provider_name: collection.provider?.name || 'N/A',
+            egress_path: collection.egress?.path || 'N/A',
         }));
+
+
 
         let filtered = [...collectionsWithDetails];
         if (searchTerm) {
@@ -104,7 +186,7 @@ function Collections() {
             );
         }
 
-        return filtered.sort((a, b) => {
+        filtered.sort((a, b) => {
             const isAsc = sorting.order === 'asc' ? 1 : -1;
             const aValue = a[sorting.orderBy];
             const bValue = b[sorting.orderBy];
@@ -113,7 +195,11 @@ function Collections() {
             if (typeof aValue === 'boolean') return (aValue === bValue ? 0 : aValue ? -1 : 1) * isAsc;
             return aValue.toString().localeCompare(bValue.toString(), undefined, { numeric: true }) * isAsc;
         });
-    }, [collections.data, providers.data, egresses.data, sorting, searchTerm]);
+        const startIndex = pagination.page * rowsPerPage - (collections.cacheStart ?? 0);
+        const endIndex = startIndex + rowsPerPage;
+
+        return filtered.slice(startIndex, endIndex);
+    }, [collections.data, providers.data, egresses.data, sorting, searchTerm, pagination.page, rowsPerPage]);
     
     const handleOpenDialog = (dialogType, data = null) => {
         if (dialogType === 'edit') {
@@ -129,17 +215,32 @@ function Collections() {
         e.preventDefault();
         setIsSubmitting(true);
         try {
+            const { short_name, provider, egress, active } = dialog.data;
+            const payload = {
+                    short_name: short_name,
+                    provider_id: provider?.id || null,
+                    egress_id: egress?.id || null,
+                    active: active
+            };
             if (dialog.open === 'create') {
-                await collectionApi.createCollection(dialog.data);
+                await collectionApi.createCollection({...payload});
                 toast.success("Collection created successfully!");
             } else if (dialog.open === 'edit') {
-                const { id, short_name, provider_id, egress_id, active } = dialog.data;
-                await collectionApi.updateCollection(id, { short_name, provider_id, egress_id, active });
+                await collectionApi.updateCollection(dialog.data.id, {...payload });
                 toast.success("Collection updated successfully");
             }
             handleCloseDialog();
             setSelected([]);
-            dispatch(fetchCollections()); // Refresh the cache
+
+            if (providers.page !== 1) {
+                dispatch(fetchProviders({ page: 1, pageSize: 50 }));
+            }
+            if (egresses.page !== 1) {
+                dispatch(fetchEgresses({ page: 1, pageSize: 50 }));
+            }
+
+            const apiPage = Math.floor((currentPage * rowsPerPage) / 50) + 1;
+            dispatch(fetchCollections({ page: apiPage, pageSize: 50 })); // Refresh the cache
         } catch (error) {
             toast.error(parseApiError(error));
         } finally {
@@ -154,7 +255,8 @@ function Collections() {
             toast.success(`${selected.length} collection(s) deleted successfully!`);
             handleCloseDialog();
             setSelected([]);
-            dispatch(fetchCollections()); // Refresh the cache
+            const apiPage = Math.floor((currentPage * rowsPerPage) / 50) + 1;
+            dispatch(fetchCollections({ page: apiPage, pageSize: 50 })); // Refresh the cache
         } catch (error) {
             toast.error(parseApiError(error));
         } finally {
@@ -172,7 +274,8 @@ function Collections() {
             }));
             toast.success("Collection status updated successfully!");
             setSelected([]);
-            dispatch(fetchCollections()); // Refresh the cache
+            const apiPage = Math.floor((currentPage * rowsPerPage) / 50) + 1;
+            dispatch(fetchCollections({ page: apiPage, pageSize: 50 })); // Refresh the cache
         } catch (error) {
             toast.error(parseApiError(error));
         } finally {
@@ -201,8 +304,120 @@ function Collections() {
         setSelected(newSelected);
     };
 
-    const handlePageChange = (event, newPage) => setPagination(prev => ({...prev, page: newPage}));
-    const handleRowsPerPageChange = (event) => setPagination({ ...pagination, pageSize: parseInt(event.target.value, 10), page: 0 });
+    const isWithinCache = (newPage) => {
+
+        if (collections.total <= collections.cacheSize) {
+            return true;
+        }
+
+        const startIndex = newPage * rowsPerPage;// use UI rowsPerPage
+        const endIndex = startIndex + rowsPerPage;
+
+        const cacheStart = collections.cacheStart ?? 0;
+        const cacheEnd = cacheStart + (collections.cacheSize ?? 0);  // usually 50
+
+        return startIndex >= cacheStart && endIndex <= cacheEnd;
+    };
+
+    const handlePageChange = (event, newPage) => {
+         setCurrentPage(newPage); // Pagination.page gets updated
+
+        if (!isWithinCache(newPage)) {
+            const apiPageSize = 50; // chunk size
+            const startIndex = newPage * rowsPerPage;
+            const apiPage = Math.floor(startIndex / apiPageSize) + 1;
+            dispatch(fetchCollections({ page: apiPage, pageSize: apiPageSize }));
+        }
+    };
+
+    const handleRowsPerPageChange = (event) => {
+        const newSize = parseInt(event.target.value, 10);
+        setCurrentPage(0);//bring back the page to 0 when the rowsperpage change
+        
+        if (!isWithinCache(0)) {
+            const apiPageSize = 50; // chunk size
+            const startIndex = 0;
+            const apiPage = Math.floor(startIndex / apiPageSize) + 1;
+            dispatch(fetchCollections({ page: apiPage, pageSize: apiPageSize }));
+        }
+        setRowsPerPage(newSize);  // only update UI rows per page
+    };
+
+    const handleProvidersScroll = (event) => {
+        const listbox = event.currentTarget;
+
+        // Scroll Down
+        if (listbox.scrollTop + listbox.clientHeight >= listbox.scrollHeight - 20) {
+
+            const nextPage = Math.floor(mergedProviders.length / providers.pageSize) + 1;
+
+            // STOP if all data is loaded
+            if (mergedProviders.length >= providers.total) return;
+
+            // STOP if already loaded
+            if (providers.loadedPages?.includes(nextPage)) return;
+
+            // STOP if already loading
+            if (providerLoadingPages.has(nextPage)) return;
+
+            // Mark as loading
+            setProviderLoadingPages(prev => new Set(prev).add(nextPage));
+
+            dispatch(fetchProviders({ page: nextPage, pageSize: providers.pageSize }));
+        }
+
+        // Scroll up
+        if (listbox.scrollTop === 0) {
+
+            // Stop if already at the beginning
+            if (mergedProviders.length >= providers.total) return;
+
+            const previousPage = Math.max(1, providers.cacheStart / providers.pageSize);
+
+            // Avoid re-fetch
+            if (providers.loadedPages?.includes(previousPage)) return;
+
+            dispatch(fetchProviders({ page: previousPage, pageSize: providers.pageSize }));
+        }
+    };
+
+    const handleEgressScroll = (event) => {
+        const listbox = event.currentTarget;
+
+        // Scroll Down
+        if (listbox.scrollTop + listbox.clientHeight >= listbox.scrollHeight - 20) {
+
+            const nextPage = Math.floor(mergedEgress.length / egresses.pageSize) + 1;
+
+            // STOP if all data is loaded
+            if (mergedEgress.length >= egresses.total) return;
+
+            // STOP if already loaded
+            if (egresses.loadedPages?.includes(nextPage)) return;
+
+            // STOP if already loading
+            if (egressLoadingPages.has(nextPage)) return;
+
+            // Mark as loading
+            setEgressLoadingPages(prev => new Set(prev).add(nextPage));
+
+            dispatch(fetchEgresses({ page: nextPage, pageSize: egresses.pageSize }));
+        }
+
+        // Scroll up
+        if (listbox.scrollTop === 0) {
+
+            // Stop if already at the beginning
+            if (mergedEgress.length >= egresses.total) return;
+
+            const previousPage = Math.max(1, egresses.cacheStart / egresses.pageSize);
+
+            // Avoid re-fetch
+            if (egresses.loadedPages?.includes(previousPage)) return;
+
+            dispatch(fetchEgresses({ page: previousPage, pageSize: egresses.pageSize }));
+        }
+    };
 
     if (location.pathname !== '/collections') {
         return <Outlet key={location.pathname} />;
@@ -255,7 +470,6 @@ function Collections() {
                                     </TableRow>
                                 ) : (
                                     processedCollections
-                                        .slice(pagination.page * pagination.pageSize, pagination.page * pagination.pageSize + pagination.pageSize)
                                         .map((collection) => {
                                             const isItemSelected = selected.indexOf(collection.id) !== -1;
                                             return (
@@ -275,7 +489,7 @@ function Collections() {
                     <TablePagination
                         rowsPerPageOptions={[10, 25, 50]}
                         component="div"
-                        count={processedCollections.length}
+                        count={pagination.total}
                         rowsPerPage={pagination.pageSize}
                         page={pagination.page}
                         onPageChange={handlePageChange}
@@ -287,11 +501,85 @@ function Collections() {
             <Dialog open={dialog.open === 'create' || dialog.open === 'edit'} onClose={handleCloseDialog} fullWidth maxWidth="sm">
                 <DialogTitle>{dialog.open === 'create' ? 'Create New Collection' : 'Edit Collection'}</DialogTitle>
                 <DialogContent>
-                    {dialog.data && (
+                    {
+                    dialog.data && (
                         <Box component="form" id="collection-form" onSubmit={handleFormSubmit} noValidate sx={{ mt: 1 }}>
                             <TextField autoFocus margin="dense" name="short_name" label="Collection Short Name" fullWidth value={dialog.data.short_name} onChange={(e) => setDialog({...dialog, data: {...dialog.data, short_name: e.target.value}})} required />
-                            <Autocomplete options={providers.data} getOptionLabel={(option) => option.short_name} value={providers.data.find(o => o.id === dialog.data.provider_id) || null} onChange={(e, val) => setDialog({...dialog, data: {...dialog.data, provider_id: val?.id || null}})} renderInput={(params) => <TextField {...params} label="Provider" margin="dense" fullWidth required />} />
-                            <Autocomplete options={egresses.data} getOptionLabel={(option) => option.path} value={egresses.data.find(o => o.id === dialog.data.egress_id) || null} onChange={(e, val) => setDialog({...dialog, data: {...dialog.data, egress_id: val?.id || null}})} renderInput={(params) => <TextField {...params} label="Egress Path" margin="dense" fullWidth required />} />
+                            <Autocomplete
+                                    fullWidth
+                                    options={mergedProviders}
+                                    getOptionLabel={(option) => option.short_name || ""}
+                                    isOptionEqualToValue={(option, value) => option?.id === value?.id}
+                                    
+                                    // Use cached user OR fallback to collections's existing provider
+                                    value={
+                                        mergedProviders.find(u => u.id === dialog.data.provider?.id) ||
+                                        (dialog.data.provider?.id ? dialog.data.provider : null)
+                                    }
+
+                                    ListboxProps={{ onScroll: handleProvidersScroll }}
+                                    loading={providers.status === 'loading'}
+
+                                    onChange={(e, newValue) => {
+                                        // Store both id and name
+                                        setDialog({
+                                            ...dialog,
+                                            data: { 
+                                                ...dialog.data, 
+                                                provider: newValue 
+                                                    ? { id: newValue.id, name: newValue.name } 
+                                                    : null 
+                                            }
+                                        });
+                                    }}
+
+                                    renderInput={(params) => (
+                                        <TextField
+                                            {...params}
+                                            label="Provider"
+                                            margin="dense"
+                                        />
+                                    )}
+                                />
+
+
+                                <Autocomplete
+                                    fullWidth
+                                    options={mergedEgress}
+                                    getOptionLabel={(option) => option.path || ""}
+                                    isOptionEqualToValue={(option, value) => option?.id === value?.id}
+                                    
+                                    // Use cached user OR fallback to collection's existing egress path
+                                    value={
+                                        mergedEgress.find(u => u.id === dialog.data.egress?.id) ||
+                                        (dialog.data.egress?.id ? dialog.data.egress : null)
+                                    }
+
+                                    ListboxProps={{ onScroll: handleEgressScroll }}
+                                    loading={egresses.status === 'loading'}
+
+                                    onChange={(e, newValue) => {
+                                        // Store both id and name
+                                        setDialog({
+                                            ...dialog,
+                                            data: { 
+                                                ...dialog.data, 
+                                                egress: newValue 
+                                                    ? { id: newValue.id, name: newValue.path } 
+                                                    : null 
+                                            }
+                                        });
+                                    }}
+
+                                    renderInput={(params) => (
+                                        <TextField
+                                            {...params}
+                                            label="Egress Path"
+                                            margin="dense"
+                                        />
+                                    )}
+                                />
+                            
                             <TextField select margin="dense" label="Status" fullWidth value={dialog.data.active} onChange={(e) => setDialog({...dialog, data: {...dialog.data, active: e.target.value }})}>
                                 <MenuItem value={true}>Active</MenuItem>
                                 <MenuItem value={false}>Inactive</MenuItem>

--- a/src/pages/Collections.js
+++ b/src/pages/Collections.js
@@ -63,6 +63,7 @@ function Collections() {
     const [searchTerm, setSearchTerm] = useState('');
     const [dialog, setDialog] = useState({ open: null, data: null });
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [filteredCount, setFilteredCount] = useState(0);
 
     const firstSelectedStatus = useMemo(() => {
         if (selected.length === 0) return true;
@@ -164,6 +165,9 @@ function Collections() {
         });
     }, [egresses.data]);
 
+    useEffect(() => {
+        setCurrentPage(0);
+    }, [searchTerm]);
 
     const processedCollections = useMemo(() => {
         if (!collections.data || !providers.data || !egresses.data) return [];
@@ -195,8 +199,32 @@ function Collections() {
             if (typeof aValue === 'boolean') return (aValue === bValue ? 0 : aValue ? -1 : 1) * isAsc;
             return aValue.toString().localeCompare(bValue.toString(), undefined, { numeric: true }) * isAsc;
         });
-        const startIndex = pagination.page * rowsPerPage - (collections.cacheStart ?? 0);
-        const endIndex = startIndex + rowsPerPage;
+        const newFilteredCount = filtered.length;
+
+        if (newFilteredCount !== filteredCount) {
+            setFilteredCount(newFilteredCount);
+        }
+        
+        let startIndex, endIndex;
+        // Prevent negative or out-of-range pages
+        const safePage = Math.max(
+            0,
+            Math.min(
+                currentPage,
+                Math.floor((filtered.length - 1) / rowsPerPage)  // max valid page
+            )
+        );
+
+        if (searchTerm) {
+            // SCENARIO 1: SEARCHING/FILTERING
+            // List contains the *entire* locally filtered/sorted set.
+            startIndex = safePage * rowsPerPage;
+            endIndex = startIndex + rowsPerPage;
+        } else {
+            // SCENARIO 2: NORMAL VIEW (PAGINATING THROUGH CACHE CHUNKS)
+            startIndex = Math.max(0, pagination.page * rowsPerPage - (collections.cacheStart ?? 0));
+            endIndex = Math.min(filtered.length, startIndex + rowsPerPage);
+        }
 
         return filtered.slice(startIndex, endIndex);
     }, [collections.data, providers.data, egresses.data, sorting, searchTerm, pagination.page, rowsPerPage]);
@@ -489,7 +517,7 @@ function Collections() {
                     <TablePagination
                         rowsPerPageOptions={[10, 25, 50]}
                         component="div"
-                        count={pagination.total}
+                        count={searchTerm ? filteredCount : pagination.total}
                         rowsPerPage={pagination.pageSize}
                         page={pagination.page}
                         onPageChange={handlePageChange}

--- a/src/pages/DAAC.js
+++ b/src/pages/DAAC.js
@@ -42,7 +42,11 @@ export default function DAAC() {
     // Local state for UI operations
     const [loading, setLoading] = useState(true);
     const [selected, setSelected] = useState([]);
-    const [pagination, setPagination] = useState({ page: 0, rowsPerPage: 10 });
+    const pagination = {
+        page: egresses.page ? egresses.page - 1 : 0,
+        pageSize: egresses.pageSize ?? 10,
+        total: egresses.total ?? 0
+    };
     const [sorting, setSorting] = useState({ orderBy: 'type', order: 'asc' });
     const [searchTerm, setSearchTerm] = useState('');
     const [dialog, setDialog] = useState({ open: null, data: null });
@@ -57,7 +61,7 @@ export default function DAAC() {
     // "Smart" data fetching that uses the cache
     useEffect(() => {
         if (activeNgroupId && egresses.status === 'idle') {
-            dispatch(fetchEgresses());
+            dispatch(fetchEgresses({ page: 1, pageSize: 10 }));
         }
     }, [activeNgroupId, egresses.status, dispatch]);
 
@@ -194,7 +198,7 @@ export default function DAAC() {
             }
             handleCloseDialog();
             setSelected([]);
-            dispatch(fetchEgresses()); // Refresh the cache
+            dispatch(fetchEgresses({ page: 1, pageSize: 10 })); // Refresh the cache
         } catch (error) {
             toast.error(parseApiError(error));
         } finally {
@@ -209,7 +213,7 @@ export default function DAAC() {
             toast.success("Egress deleted successfully!");
             handleCloseDialog();
             setSelected([]);
-            dispatch(fetchEgresses()); // Refresh the cache
+            dispatch(fetchEgresses({ page: 1, pageSize: 10 })); // Refresh the cache
         } catch (error) {
             toast.error(parseApiError(error));
         } finally {
@@ -230,6 +234,14 @@ export default function DAAC() {
         if (selectedIndex === -1) newSelected = [...selected, id];
         else newSelected = selected.filter(selId => selId !== id);
         setSelected(newSelected);
+    };
+
+    const handlePageChange = (event, newPage) => {
+            dispatch(fetchEgresses({ page: newPage+1, pageSize: pagination.pageSize }));
+        };
+    const handleRowsPerPageChange = (event) => {
+        const newSize = parseInt(event.target.value, 10);
+        dispatch(fetchEgresses({ page: 1, pageSize: newSize }));
     };
 
     return (
@@ -275,7 +287,7 @@ export default function DAAC() {
                                         </TableCell>
                                     </TableRow>
                                 ) : (
-                                    processedEgresses.slice(pagination.page * pagination.rowsPerPage, pagination.page * pagination.rowsPerPage + pagination.rowsPerPage).map((row) => {
+                                    processedEgresses.map((row) => {
                                         const isItemSelected = selected.indexOf(row.id) !== -1;
                                         return (
                                             <TableRow key={row.id} hover onClick={() => handleClick(row.id)} role="checkbox" tabIndex={-1} selected={isItemSelected}>
@@ -293,11 +305,11 @@ export default function DAAC() {
                     <TablePagination
                         rowsPerPageOptions={[10, 25, 50]}
                         component="div"
-                        count={processedEgresses.length}
-                        rowsPerPage={pagination.rowsPerPage}
+                        count={pagination.total}
+                        rowsPerPage={pagination.pageSize}
                         page={pagination.page}
-                        onPageChange={(e, newPage) => setPagination(prev => ({ ...prev, page: newPage }))}
-                        onRowsPerPageChange={(e) => setPagination({ rowsPerPage: parseInt(e.target.value, 10), page: 0 })}
+                        onPageChange={handlePageChange}
+                        onRowsPerPageChange={handleRowsPerPageChange}
                     />
                 </CardContent>
             </Card>

--- a/src/pages/DAAC.js
+++ b/src/pages/DAAC.js
@@ -42,9 +42,11 @@ export default function DAAC() {
     // Local state for UI operations
     const [loading, setLoading] = useState(true);
     const [selected, setSelected] = useState([]);
+    const [rowsPerPage, setRowsPerPage] = useState(10);
+    const [currentPage, setCurrentPage] = useState(0); // 0-based for MUI TablePagination
     const pagination = {
-        page: egresses.page ? egresses.page - 1 : 0,
-        pageSize: egresses.pageSize ?? 10,
+        page: currentPage,
+        pageSize: rowsPerPage,
         total: egresses.total ?? 0
     };
     const [sorting, setSorting] = useState({ orderBy: 'type', order: 'asc' });
@@ -80,13 +82,17 @@ export default function DAAC() {
             );
         }
 
-        return filtered.sort((a, b) => {
+        filtered.sort((a, b) => {
             const isAsc = sorting.order === 'asc' ? 1 : -1;
             const aValue = a[sorting.orderBy] || '';
             const bValue = b[sorting.orderBy] || '';
             return aValue.localeCompare(bValue) * isAsc;
         });
-    }, [egresses.data, sorting, searchTerm]);
+        const startIndex = pagination.page * rowsPerPage - (egresses.cacheStart ?? 0);
+        const endIndex = startIndex + rowsPerPage;
+
+        return filtered.slice(startIndex, endIndex);
+    }, [egresses.data, sorting, searchTerm, pagination.page, rowsPerPage]);
 
     const handleOpenDialog = (type, data = null) => {
         if (type === 'edit') {
@@ -236,12 +242,37 @@ export default function DAAC() {
         setSelected(newSelected);
     };
 
+    const isWithinCache = (newPage) => {
+        const startIndex = newPage * rowsPerPage;// use UI rowsPerPage
+        const endIndex = startIndex + rowsPerPage;
+
+        const cacheStart = egresses.cacheStart ?? 0;
+        const cacheEnd = cacheStart + (egresses.cacheSize ?? 0);  // usually 50
+
+        return startIndex >= cacheStart && endIndex <= cacheEnd;
+    };
+
     const handlePageChange = (event, newPage) => {
-            dispatch(fetchEgresses({ page: newPage+1, pageSize: pagination.pageSize }));
-        };
+        setCurrentPage(newPage); // Pagination.page gets updated
+
+        if (!isWithinCache(newPage)) {
+            const apiPageSize = 50; // chunk size
+            const startIndex = newPage * rowsPerPage;
+            const apiPage = Math.floor(startIndex / apiPageSize) + 1;
+            dispatch(fetchEgresses({ page: apiPage, pageSize: apiPageSize }));
+        }
+    };
+
     const handleRowsPerPageChange = (event) => {
         const newSize = parseInt(event.target.value, 10);
-        dispatch(fetchEgresses({ page: 1, pageSize: newSize }));
+        setCurrentPage(0);//bring back the page to 0 when the rowsperpage change
+        if (!isWithinCache(0)) {
+            const apiPageSize = 50; // chunk size
+            const startIndex = 0;
+            const apiPage = Math.floor(startIndex / apiPageSize) + 1;
+            dispatch(fetchEgresses({ page: apiPage, pageSize: apiPageSize }));
+        }
+        setRowsPerPage(newSize);  // only update UI rows per page
     };
 
     return (

--- a/src/pages/DAAC.js
+++ b/src/pages/DAAC.js
@@ -66,8 +66,10 @@ export default function DAAC() {
 
     // "Smart" data fetching that uses the cache
     useEffect(() => {
-        if (activeNgroupId && (egresses.status === 'idle' || !didMount.current)) {
-            dispatch(fetchEgresses({ page: 1, pageSize: 50 }));
+        if (activeNgroupId && !didMount.current) {
+            if (egresses.status === 'idle' ||  egresses.page !== 1){
+                dispatch(fetchEgresses({ page: 1, pageSize: 50 }));
+            }
             didMount.current = true;
         }
     }, [activeNgroupId, egresses.status, dispatch]);

--- a/src/pages/DAAC.js
+++ b/src/pages/DAAC.js
@@ -53,6 +53,7 @@ export default function DAAC() {
     const [searchTerm, setSearchTerm] = useState('');
     const [dialog, setDialog] = useState({ open: null, data: null });
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [filteredCount, setFilteredCount] = useState(0);
 
     useEffect(() => {
         const daacMenuItems = [{ text: 'Egress', path: '/daac', icon: <OutputIcon /> }];
@@ -72,6 +73,10 @@ export default function DAAC() {
         setLoading(egresses.status === 'loading');
     }, [egresses.status]);
 
+    useEffect(() => {
+        setCurrentPage(0);
+    }, [searchTerm]);
+
     const processedEgresses = useMemo(() => {
         let filtered = [...egresses.data];
         if (searchTerm) {
@@ -88,9 +93,32 @@ export default function DAAC() {
             const bValue = b[sorting.orderBy] || '';
             return aValue.localeCompare(bValue) * isAsc;
         });
-        const startIndex = pagination.page * rowsPerPage - (egresses.cacheStart ?? 0);
-        const endIndex = startIndex + rowsPerPage;
+        const newFilteredCount = filtered.length;
 
+        if (newFilteredCount !== filteredCount) {
+            setFilteredCount(newFilteredCount);
+        }
+        
+        let startIndex, endIndex;
+        // Prevent negative or out-of-range pages
+        const safePage = Math.max(
+            0,
+            Math.min(
+                currentPage,
+                Math.floor((filtered.length - 1) / rowsPerPage)  // max valid page
+            )
+        );
+
+        if (searchTerm) {
+            // SCENARIO 1: SEARCHING/FILTERING
+            // List contains the *entire* locally filtered/sorted set.
+            startIndex = safePage * rowsPerPage;
+            endIndex = startIndex + rowsPerPage;
+        } else {
+            // SCENARIO 2: NORMAL VIEW (PAGINATING THROUGH CACHE CHUNKS)
+            startIndex = Math.max(0, pagination.page * rowsPerPage - (egresses.cacheStart ?? 0));
+            endIndex = Math.min(filtered.length, startIndex + rowsPerPage);
+        }
         return filtered.slice(startIndex, endIndex);
     }, [egresses.data, sorting, searchTerm, pagination.page, rowsPerPage]);
 
@@ -341,7 +369,7 @@ export default function DAAC() {
                     <TablePagination
                         rowsPerPageOptions={[10, 25, 50]}
                         component="div"
-                        count={pagination.total}
+                        count={searchTerm ? filteredCount : pagination.total}
                         rowsPerPage={pagination.pageSize}
                         page={pagination.page}
                         onPageChange={handlePageChange}

--- a/src/pages/DAAC.js
+++ b/src/pages/DAAC.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import { useOutletContext } from 'react-router-dom';
 import {
     Box, Card, CardContent, Button, Table, TableBody, TableCell,
@@ -54,7 +54,7 @@ export default function DAAC() {
     const [dialog, setDialog] = useState({ open: null, data: null });
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [filteredCount, setFilteredCount] = useState(0);
-    const [initialLoadComplete, setInitialLoadComplete] = useState(false);
+    const didMount = useRef(false);
 
     useEffect(() => {
         const daacMenuItems = [{ text: 'Egress', path: '/daac', icon: <OutputIcon /> }];
@@ -64,9 +64,9 @@ export default function DAAC() {
 
     // "Smart" data fetching that uses the cache
     useEffect(() => {
-        if (activeNgroupId && (egresses.status === 'idle' || (!initialLoadComplete && egresses.page !== 1))) {
+        if (activeNgroupId && (egresses.status === 'idle' || !didMount.current)) {
             dispatch(fetchEgresses({ page: 1, pageSize: 50 }));
-            setInitialLoadComplete(true);
+            didMount.current = true;
         }
     }, [activeNgroupId, egresses.status, dispatch]);
 

--- a/src/pages/DAAC.js
+++ b/src/pages/DAAC.js
@@ -54,6 +54,7 @@ export default function DAAC() {
     const [dialog, setDialog] = useState({ open: null, data: null });
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [filteredCount, setFilteredCount] = useState(0);
+    const [initialLoadComplete, setInitialLoadComplete] = useState(false);
 
     useEffect(() => {
         const daacMenuItems = [{ text: 'Egress', path: '/daac', icon: <OutputIcon /> }];
@@ -63,8 +64,9 @@ export default function DAAC() {
 
     // "Smart" data fetching that uses the cache
     useEffect(() => {
-        if (activeNgroupId && egresses.status === 'idle') {
+        if (activeNgroupId && (egresses.status === 'idle' || (!initialLoadComplete && egresses.page !== 1))) {
             dispatch(fetchEgresses({ page: 1, pageSize: 50 }));
+            setInitialLoadComplete(true);
         }
     }, [activeNgroupId, egresses.status, dispatch]);
 
@@ -76,6 +78,16 @@ export default function DAAC() {
     useEffect(() => {
         setCurrentPage(0);
     }, [searchTerm]);
+
+    // Reset pagination when ngroup changes or when new collections load
+    useEffect(() => {
+        const maxPage = Math.floor((egresses.total - 1) / rowsPerPage) || 0;
+
+        // if currentPage is invalid, reset to 0
+        if (currentPage > maxPage) {
+            setCurrentPage(0);
+        }
+    }, [activeNgroupId, egresses.total]);
 
     const processedEgresses = useMemo(() => {
         let filtered = [...egresses.data];

--- a/src/pages/DAAC.js
+++ b/src/pages/DAAC.js
@@ -61,7 +61,7 @@ export default function DAAC() {
     // "Smart" data fetching that uses the cache
     useEffect(() => {
         if (activeNgroupId && egresses.status === 'idle') {
-            dispatch(fetchEgresses({ page: 1, pageSize: 10 }));
+            dispatch(fetchEgresses({ page: 1, pageSize: 50 }));
         }
     }, [activeNgroupId, egresses.status, dispatch]);
 
@@ -198,7 +198,7 @@ export default function DAAC() {
             }
             handleCloseDialog();
             setSelected([]);
-            dispatch(fetchEgresses({ page: 1, pageSize: 10 })); // Refresh the cache
+            dispatch(fetchEgresses({ page: 1, pageSize: 50 })); // Refresh the cache
         } catch (error) {
             toast.error(parseApiError(error));
         } finally {
@@ -213,7 +213,7 @@ export default function DAAC() {
             toast.success("Egress deleted successfully!");
             handleCloseDialog();
             setSelected([]);
-            dispatch(fetchEgresses({ page: 1, pageSize: 10 })); // Refresh the cache
+            dispatch(fetchEgresses({ page: 1, pageSize: 50 })); // Refresh the cache
         } catch (error) {
             toast.error(parseApiError(error));
         } finally {

--- a/src/pages/DAAC.js
+++ b/src/pages/DAAC.js
@@ -245,6 +245,9 @@ export default function DAAC() {
     };
 
     const isWithinCache = (newPage) => {
+        if (egresses.total <= egresses.cacheSize) {
+            return true;
+        }
         const startIndex = newPage * rowsPerPage;// use UI rowsPerPage
         const endIndex = startIndex + rowsPerPage;
 

--- a/src/pages/DAAC.js
+++ b/src/pages/DAAC.js
@@ -204,7 +204,8 @@ export default function DAAC() {
             }
             handleCloseDialog();
             setSelected([]);
-            dispatch(fetchEgresses({ page: 1, pageSize: 50 })); // Refresh the cache
+            const apiPage = Math.floor((currentPage * rowsPerPage) / 50) + 1;
+            dispatch(fetchEgresses({ page: apiPage, pageSize: 50 })); // Refresh the cache
         } catch (error) {
             toast.error(parseApiError(error));
         } finally {
@@ -219,7 +220,8 @@ export default function DAAC() {
             toast.success("Egress deleted successfully!");
             handleCloseDialog();
             setSelected([]);
-            dispatch(fetchEgresses({ page: 1, pageSize: 50 })); // Refresh the cache
+            const apiPage = Math.floor((currentPage * rowsPerPage) / 50) + 1;
+            dispatch(fetchEgresses({ page: apiPage, pageSize: 50 })); // Refresh the cache
         } catch (error) {
             toast.error(parseApiError(error));
         } finally {

--- a/src/pages/DAAC.js
+++ b/src/pages/DAAC.js
@@ -55,6 +55,8 @@ export default function DAAC() {
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [filteredCount, setFilteredCount] = useState(0);
     const didMount = useRef(false);
+    const [prevPage, setPrevPage] = useState(0);
+    const wasSearching = useRef(false);
 
     useEffect(() => {
         const daacMenuItems = [{ text: 'Egress', path: '/daac', icon: <OutputIcon /> }];
@@ -89,6 +91,23 @@ export default function DAAC() {
         }
     }, [activeNgroupId, egresses.total]);
 
+    useEffect(() => {
+            const isSearching = searchTerm.trim() !== "";
+    
+            if (isSearching && !wasSearching.current) {
+                // Search just started — store page ONCE
+                setPrevPage(currentPage);
+                setCurrentPage(0);
+            }
+    
+            if (!isSearching && wasSearching.current) {
+                // Search just ended — restore ONCE
+                setCurrentPage(prevPage);
+            }
+    
+            wasSearching.current = isSearching;
+        }, [searchTerm, currentPage, prevPage]);
+
     const processedEgresses = useMemo(() => {
         let filtered = [...egresses.data];
         if (searchTerm) {
@@ -112,19 +131,18 @@ export default function DAAC() {
         }
         
         let startIndex, endIndex;
-        // Prevent negative or out-of-range pages
-        const safePage = Math.max(
-            0,
-            Math.min(
-                currentPage,
-                Math.floor((filtered.length - 1) / rowsPerPage)  // max valid page
-            )
-        );
 
         if (searchTerm) {
             // SCENARIO 1: SEARCHING/FILTERING
             // List contains the *entire* locally filtered/sorted set.
-            startIndex = safePage * rowsPerPage;
+            const maxFilteredPage = Math.max(
+                0,
+                Math.floor((filtered.length - 1) / rowsPerPage)
+            );
+
+            const safeSearchPage = Math.min(currentPage, maxFilteredPage);
+
+            startIndex = safeSearchPage * rowsPerPage;
             endIndex = startIndex + rowsPerPage;
         } else {
             // SCENARIO 2: NORMAL VIEW (PAGINATING THROUGH CACHE CHUNKS)
@@ -303,8 +321,10 @@ export default function DAAC() {
         if (!isWithinCache(newPage)) {
             const apiPageSize = 50; // chunk size
             const startIndex = newPage * rowsPerPage;
-            const apiPage = Math.floor(startIndex / apiPageSize) + 1;
-            dispatch(fetchEgresses({ page: apiPage, pageSize: apiPageSize }));
+            if (!searchTerm){
+                const apiPage = Math.floor(startIndex / apiPageSize) + 1;
+                dispatch(fetchEgresses({ page: apiPage, pageSize: apiPageSize }));
+            }
         }
     };
 
@@ -314,8 +334,10 @@ export default function DAAC() {
         if (!isWithinCache(0)) {
             const apiPageSize = 50; // chunk size
             const startIndex = 0;
-            const apiPage = Math.floor(startIndex / apiPageSize) + 1;
-            dispatch(fetchEgresses({ page: apiPage, pageSize: apiPageSize }));
+            if (!searchTerm){
+                const apiPage = Math.floor(startIndex / apiPageSize) + 1;
+                dispatch(fetchEgresses({ page: apiPage, pageSize: apiPageSize }));
+            }
         }
         setRowsPerPage(newSize);  // only update UI rows per page
     };

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import {
     Box,
     Grid,

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -99,12 +99,12 @@ export default function Home() {
 
     useEffect(() => {
         if (activeNgroupId) {
-            if (collections.status === 'idle') dispatch(fetchCollections({ page: 1, pageSize: 10 }));
-            if (providers.status === 'idle') dispatch(fetchProviders({ page: 1, pageSize: 10 }));
-            if (egresses.status === 'idle') dispatch(fetchEgresses({ page: 1, pageSize: 10 }));
+            if (collections.status === 'idle') dispatch(fetchCollections({ page: 1, pageSize: 50 }));
+            if (providers.status === 'idle') dispatch(fetchProviders({ page: 1, pageSize: 50 }));
+            if (egresses.status === 'idle') dispatch(fetchEgresses({ page: 1, pageSize: 50 }));
             // MODIFICATION: Conditionally fetch users based on privilege
             if (users.status === 'idle' && hasPrivilege('user:page')) {
-                dispatch(fetchUsers({ page: 1, pageSize: 10 }));
+                dispatch(fetchUsers({ page: 1, pageSize: 50 }));
             }
         }
     }, [activeNgroupId, collections.status, providers.status, egresses.status, users.status, dispatch, hasPrivilege]);

--- a/src/pages/Profile/ApiKeys.js
+++ b/src/pages/Profile/ApiKeys.js
@@ -40,6 +40,7 @@ function ApiKeys() {
     const [orderBy, setOrderBy] = useState('created_at');
     const [revokeDialogOpen, setRevokeDialogOpen] = useState(false);
     const [suspendDialogOpen, setSuspendDialogOpen] = useState(false);
+    const [total, setTotal] = useState(0);
 
     const fetchApiKeys = useCallback(async () => {
         // Guard against running if no group is selected.
@@ -51,15 +52,20 @@ function ApiKeys() {
         setLoading(true);
         setSelected([]);
         try {
-            const data = await getApiKeys();
-            setApiKeys(data);
+            const response = await getApiKeys({
+                page: page + 1,      // state variable
+                page_size: rowsPerPage,
+            });
+            setApiKeys(response.api_keys);
+            setTotal(response.total);
+            setPage(response.page - 1);
         } catch (err) {
             toast.error(parseApiError(err));
         } finally {
             setLoading(false);
         }
-    // activeNgroupId to the dependency array.
-    }, [activeNgroupId]);
+    // Added activeNgroupId to the dependency array.
+    }, [activeNgroupId, page, rowsPerPage]);
 
     useEffect(() => {
         fetchApiKeys();
@@ -83,9 +89,6 @@ function ApiKeys() {
         return filtered.sort(comparator);
     }, [apiKeys, order, orderBy, searchTerm]);
 
-    const visibleRows = useMemo(() => {
-        return filteredAndSortedKeys.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage);
-    }, [filteredAndSortedKeys, page, rowsPerPage]);
 
     const handleRequestSort = (property) => {
         const isAsc = orderBy === property && order === 'asc';
@@ -178,7 +181,7 @@ function ApiKeys() {
                             </TableHead>
                             <TableBody>
                                 {loading ? <TableRow><TableCell colSpan={9} align="center"><CircularProgress /></TableCell></TableRow>
-                                    : visibleRows.length > 0 ? visibleRows.map((row) => {
+                                    : filteredAndSortedKeys.length > 0 ? filteredAndSortedKeys.map((row) => {
                                         const isItemSelected = isSelected(row.id);
                                         const isExpired = row.expires_at && new Date(row.expires_at) < new Date();
                                         return (
@@ -207,7 +210,7 @@ function ApiKeys() {
                     <TablePagination
                         rowsPerPageOptions={[10, 25, 50]}
                         component="div"
-                        count={filteredAndSortedKeys.length}
+                        count={searchTerm ? filteredAndSortedKeys.length: total}
                         rowsPerPage={rowsPerPage}
                         page={page}
                         onPageChange={handleChangePage}

--- a/src/pages/Profile/CreateApiKeyModal.js
+++ b/src/pages/Profile/CreateApiKeyModal.js
@@ -27,6 +27,12 @@ export default function CreateApiKeyModal({ open, onClose, onKeyCreated }) {
   const [users, setUsers] = React.useState([]);
   const [isUsersLoading, setIsUsersLoading] = React.useState(false);
   const [newKey, setNewKey] = React.useState(null);
+  const [usersPage, setUsersPage] = React.useState(1);
+  const [usersPageSize] = React.useState(50);
+  const [usersTotal, setUsersTotal] = React.useState(0);
+  const [fetchedPages, setFetchedPages] = React.useState(new Set());
+  const [keyNameError, setKeyNameError] = React.useState('');
+
   
   // ---  State to manage scope checkboxes. Both are enabled by default. ---
   const [scopes, setScopes] = React.useState({
@@ -43,12 +49,34 @@ export default function CreateApiKeyModal({ open, onClose, onKeyCreated }) {
   React.useEffect(() => {
     if (open && hasPrivilege('api-key:create')) {
       setIsUsersLoading(true);
-      listCueusers()
-        .then(data => setUsers(data))
-        .catch(err => toast.error("Could not load user list."))
-        .finally(() => setIsUsersLoading(false));
+      fetchUsersPage(usersPage);
     }
   }, [open, hasPrivilege]);
+
+  const fetchUsersPage = async (pageNumber) => {
+    if (fetchedPages.has(pageNumber) || isUsersLoading) return; // guard against duplicates
+    setIsUsersLoading(true);
+    
+    try {
+      const response = await listCueusers(pageNumber, usersPageSize);
+      const data = response; // assuming axios
+      
+      setUsers(prev => [
+        ...prev,
+        ...data.users.filter(u => !prev.some(pu => pu.id === u.id))
+      ]);
+      setUsersTotal(data.total);
+      setUsersPage(pageNumber);
+      
+      setFetchedPages(prev => new Set(prev).add(pageNumber)); // mark page as fetched
+    } catch (err) {
+      toast.error("Could not load user list.");
+    } finally {
+      setIsUsersLoading(false);
+    }
+  };
+
+
 
   const handleClose = () => {
     if (isSubmitting) return;
@@ -145,6 +173,7 @@ export default function CreateApiKeyModal({ open, onClose, onKeyCreated }) {
   const atLeastOneScopeSelected = Object.values(scopes).some(v => v);
   const isFormInvalid =
     !keyName.trim() ||
+    keyName.trim().length < 3 ||
     !activeNgroupId ||
     (ownerType === 'user' && !selectedUser) ||
     (ownerType === 'proxy' && !proxyUserName.trim()) ||
@@ -155,7 +184,25 @@ export default function CreateApiKeyModal({ open, onClose, onKeyCreated }) {
       <>
         <DialogTitle>Create New API Key</DialogTitle>
         <DialogContent dividers>
-          <TextField autoFocus label="Key Name" fullWidth value={keyName} onChange={(e) => setKeyName(e.target.value)} sx={{ mb: 3 }} />
+          <TextField
+            autoFocus
+            label="Key Name"
+            fullWidth
+            value={keyName}
+            onChange={(e) => {
+              setKeyName(e.target.value);
+              if (keyNameError) setKeyNameError(''); // clear error while typing
+            }}
+            onBlur={() => {
+              if (keyName.trim().length > 0 && keyName.trim().length < 3) {
+                setKeyNameError('The minimum characters required is 3');
+              }
+            }}
+            error={!!keyNameError}
+            helperText={keyNameError}
+            sx={{ mb: 3 }}
+          />
+
           <FormControl component="fieldset" sx={{ mb: 3 }}>
             <FormLabel component="legend">Key Owner</FormLabel>
             <RadioGroup row value={ownerType} onChange={(e) => setOwnerType(e.target.value)}>
@@ -169,11 +216,29 @@ export default function CreateApiKeyModal({ open, onClose, onKeyCreated }) {
             <Autocomplete
               options={users}
               getOptionLabel={(option) => `${option.name} (@${option.cueusername})`}
+              isOptionEqualToValue={(option, value) => option?.id === value?.id}
               loading={isUsersLoading}
-              value={selectedUser}
-              onChange={(event, newValue) => setSelectedUser(newValue)}
+              value={users.find(u => u.id === selectedUser?.id) || null}
+              onChange={(event, newValue) => setSelectedUser(newValue ? { id: newValue.id } : null)}
               renderInput={(params) => <TextField {...params} label="Search for a user..." variant="outlined" />}
-              sx={{ mb: 3 }}
+              ListboxProps={{
+                onScroll: (event) => {
+                  const listboxNode = event.currentTarget;
+                  const scrollTop = listboxNode.scrollTop;
+                  const scrollHeight = listboxNode.scrollHeight;
+                  const clientHeight = listboxNode.clientHeight;
+
+                  // scroll down
+                  if (scrollTop + clientHeight >= scrollHeight - 20 && users.length < usersTotal) {
+                    fetchUsersPage(usersPage + 1);
+                  }
+
+                  // scroll up
+                  if (scrollTop <= 20 && usersPage > 1) {
+                    fetchUsersPage(usersPage - 1);
+                  }
+                }
+              }}
             />
           )}
           

--- a/src/pages/Providers.js
+++ b/src/pages/Providers.js
@@ -64,7 +64,8 @@ function Providers() {
     const [sorting, setSorting] = useState({ orderBy: 'short_name', order: 'asc' });
 
     const [mergedUsers, setMergedUsers] = useState([]);
-    const [filteredCount, setFilteredCount] = useState(0); 
+    const [filteredCount, setFilteredCount] = useState(0);
+    const [initialLoadComplete, setInitialLoadComplete] = useState(false);
     
     useEffect(() => {
         const providersMenuItems = [{ text: 'Providers', path: '/providers', icon: <AccountBoxIcon /> }];
@@ -74,7 +75,10 @@ function Providers() {
 
     useEffect(() => {
         if (activeNgroupId) {
-            if (providers.status === 'idle') dispatch(fetchProviders({ page: 1, pageSize: 50 }));
+            if (providers.status === 'idle' || (!initialLoadComplete && providers.page !== 1)) {
+                dispatch(fetchProviders({ page: 1, pageSize: 50 }));
+                setInitialLoadComplete(true);
+            }
             if (users.status === 'idle') dispatch(fetchUsers({ page: 1, pageSize: 50 }));
         }
     }, [activeNgroupId, providers.status, users.status, dispatch]);
@@ -124,7 +128,14 @@ function Providers() {
         setCurrentPage(0);
     }, [searchTerm, filter]);
 
+    useEffect(() => {
+        const maxPage = Math.floor((providers.total - 1) / rowsPerPage) || 0;
 
+        // if currentPage is invalid, reset to 0
+        if (currentPage > maxPage) {
+            setCurrentPage(0);
+        }
+    }, [activeNgroupId, providers.total]);
 
     const processedProviders = useMemo(() => {
         if (!providers.data || !users.data) return [];

--- a/src/pages/Providers.js
+++ b/src/pages/Providers.js
@@ -66,6 +66,8 @@ function Providers() {
     const [mergedUsers, setMergedUsers] = useState([]);
     const [filteredCount, setFilteredCount] = useState(0);
     const didMount = useRef(false);
+    const [prevPage, setPrevPage] = useState(0);
+    const wasSearching = useRef(false);
     
     useEffect(() => {
         const providersMenuItems = [{ text: 'Providers', path: '/providers', icon: <AccountBoxIcon /> }];
@@ -137,6 +139,23 @@ function Providers() {
         }
     }, [activeNgroupId, providers.total]);
 
+    useEffect(() => {
+        const isSearching = searchTerm.trim() !== "";
+
+        if (isSearching && !wasSearching.current) {
+            // Search just started — store page ONCE
+            setPrevPage(currentPage);
+            setCurrentPage(0);
+        }
+
+        if (!isSearching && wasSearching.current) {
+            // Search just ended — restore ONCE
+            setCurrentPage(prevPage);
+        }
+
+        wasSearching.current = isSearching;
+    }, [searchTerm, currentPage, prevPage]);
+
     const processedProviders = useMemo(() => {
         if (!providers.data || !users.data) return [];
         
@@ -174,19 +193,18 @@ function Providers() {
         }
         
         let startIndex, endIndex;
-        // Prevent negative or out-of-range pages
-        const safePage = Math.max(
-            0,
-            Math.min(
-                currentPage,
-                Math.floor((list.length - 1) / rowsPerPage)  // max valid page
-            )
-        );
 
         if (searchTerm || filter !== 'all') {
             // SCENARIO 1: SEARCHING/FILTERING
             // List contains the *entire* locally filtered/sorted set.
-            startIndex = safePage * rowsPerPage;
+           const maxFilteredPage = Math.max(
+                0,
+                Math.floor((list.length - 1) / rowsPerPage)
+            );
+
+            const safeSearchPage = Math.min(currentPage, maxFilteredPage);
+
+            startIndex = safeSearchPage * rowsPerPage;
             endIndex = startIndex + rowsPerPage;
         } else {
             // SCENARIO 2: NORMAL VIEW (PAGINATING THROUGH CACHE CHUNKS)
@@ -301,8 +319,10 @@ function Providers() {
         if (!isWithinCache(newPage)) {
             const apiPageSize = 50; // chunk size
             const startIndex = newPage * rowsPerPage;
-            const apiPage = Math.floor(startIndex / apiPageSize) + 1;
-            dispatch(fetchProviders({ page: apiPage, pageSize: apiPageSize }));
+            if (!searchTerm){
+                const apiPage = Math.floor(startIndex / apiPageSize) + 1;
+                dispatch(fetchProviders({ page: apiPage, pageSize: apiPageSize }));
+            }
         }
     };
 
@@ -313,8 +333,10 @@ function Providers() {
         if (!isWithinCache(0)) {
             const apiPageSize = 50; // chunk size
             const startIndex = 0;
-            const apiPage = Math.floor(startIndex / apiPageSize) + 1;
-            dispatch(fetchProviders({ page: apiPage, pageSize: apiPageSize }));
+            if (!searchTerm){
+                const apiPage = Math.floor(startIndex / apiPageSize) + 1;
+                dispatch(fetchProviders({ page: apiPage, pageSize: apiPageSize }));
+            }
         }
         setRowsPerPage(newSize);  // only update UI rows per page
     };

--- a/src/pages/Providers.js
+++ b/src/pages/Providers.js
@@ -64,6 +64,7 @@ function Providers() {
     const [sorting, setSorting] = useState({ orderBy: 'short_name', order: 'asc' });
 
     const [mergedUsers, setMergedUsers] = useState([]);
+    const [filteredCount, setFilteredCount] = useState(0); 
     
     useEffect(() => {
         const providersMenuItems = [{ text: 'Providers', path: '/providers', icon: <AccountBoxIcon /> }];
@@ -119,6 +120,11 @@ function Providers() {
         });
     }, [users.data]);
 
+    useEffect(() => {
+        setCurrentPage(0);
+    }, [searchTerm, filter]);
+
+
 
     const processedProviders = useMemo(() => {
         if (!providers.data || !users.data) return [];
@@ -150,9 +156,33 @@ function Providers() {
             return aValue.toString().localeCompare(bValue.toString(), undefined, { numeric: true }) * isAsc;
         });
 
-        const startIndex = pagination.page * rowsPerPage - (providers.cacheStart ?? 0);
-        const endIndex = startIndex + rowsPerPage;
+        const newFilteredCount = list.length;
 
+        if (newFilteredCount !== filteredCount) {
+            setFilteredCount(newFilteredCount);
+        }
+        
+        let startIndex, endIndex;
+        // Prevent negative or out-of-range pages
+        const safePage = Math.max(
+            0,
+            Math.min(
+                currentPage,
+                Math.floor((list.length - 1) / rowsPerPage)  // max valid page
+            )
+        );
+
+        if (searchTerm || filter !== 'all') {
+            // SCENARIO 1: SEARCHING/FILTERING
+            // List contains the *entire* locally filtered/sorted set.
+            startIndex = safePage * rowsPerPage;
+            endIndex = startIndex + rowsPerPage;
+        } else {
+            // SCENARIO 2: NORMAL VIEW (PAGINATING THROUGH CACHE CHUNKS)
+            startIndex = Math.max(0, pagination.page * rowsPerPage - (providers.cacheStart ?? 0));
+            endIndex = Math.min(list.length, startIndex + rowsPerPage);
+        }
+        
         return list.slice(startIndex, endIndex);
     }, [providers.data, users.data, sorting, searchTerm, filter, pagination.page, rowsPerPage]);
 
@@ -414,7 +444,7 @@ function Providers() {
                     <TablePagination
                         rowsPerPageOptions={[10, 25, 50]}
                         component="div"
-                        count={pagination.total}
+                        count={searchTerm || filter !== 'all' ? filteredCount : pagination.total}
                         rowsPerPage={pagination.pageSize}
                         page={pagination.page}
                         onPageChange={handlePageChange}

--- a/src/pages/Providers.js
+++ b/src/pages/Providers.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import {
     Box, Card, CardContent, Button, Table, TableBody, TableCell,
     TableContainer, TableHead, TableRow, Paper, Typography, Checkbox,
@@ -65,7 +65,7 @@ function Providers() {
 
     const [mergedUsers, setMergedUsers] = useState([]);
     const [filteredCount, setFilteredCount] = useState(0);
-    const [initialLoadComplete, setInitialLoadComplete] = useState(false);
+    const didMount = useRef(false);
     
     useEffect(() => {
         const providersMenuItems = [{ text: 'Providers', path: '/providers', icon: <AccountBoxIcon /> }];
@@ -75,9 +75,9 @@ function Providers() {
 
     useEffect(() => {
         if (activeNgroupId) {
-            if (providers.status === 'idle' || (!initialLoadComplete && providers.page !== 1)) {
+            if (providers.status === 'idle' || !didMount.current) {
                 dispatch(fetchProviders({ page: 1, pageSize: 50 }));
-                setInitialLoadComplete(true);
+                didMount.current = true;
             }
             if (users.status === 'idle') dispatch(fetchUsers({ page: 1, pageSize: 50 }));
         }

--- a/src/pages/Providers.js
+++ b/src/pages/Providers.js
@@ -31,7 +31,7 @@ const headCells = [
     { id: 'short_name', label: 'Short Name' },
     { id: 'long_name', label: 'Long Name' },
     { id: 'can_upload', label: 'Can Upload' },
-    { id: 'point_of_contact_name', label: 'Point of Contact' },
+    { id: 'point_of_contact.id', label: 'Point of Contact' },
     { id: 'reason', label: 'Reason' },
 ];
 
@@ -47,7 +47,14 @@ function Providers() {
 
     const [loading, setLoading] = useState(true);
     const [selected, setSelected] = useState([]);
-    const [pagination, setPagination] = useState({ page: 0, rowsPerPage: 10 });
+    const [rowsPerPage, setRowsPerPage] = useState(10);
+    const [currentPage, setCurrentPage] = useState(0); // 0-based for MUI TablePagination
+    const pagination = {
+        page: currentPage,
+        pageSize: rowsPerPage,
+        total: providers.total ?? 0
+    };
+    const [loadingPages, setLoadingPages] = useState(new Set());
     const [searchTerm, setSearchTerm] = useState('');
     const [filter, setFilter] = useState('all');
     const [dialog, setDialog] = useState({ open: null, data: null });
@@ -55,6 +62,8 @@ function Providers() {
     
     // UPDATED: Restored the missing state declaration for sorting
     const [sorting, setSorting] = useState({ orderBy: 'short_name', order: 'asc' });
+
+    const [mergedUsers, setMergedUsers] = useState([]);
     
     useEffect(() => {
         const providersMenuItems = [{ text: 'Providers', path: '/providers', icon: <AccountBoxIcon /> }];
@@ -64,8 +73,8 @@ function Providers() {
 
     useEffect(() => {
         if (activeNgroupId) {
-            if (providers.status === 'idle') dispatch(fetchProviders());
-            if (users.status === 'idle') dispatch(fetchUsers());
+            if (providers.status === 'idle') dispatch(fetchProviders({ page: 1, pageSize: 50 }));
+            if (users.status === 'idle') dispatch(fetchUsers({ page: 1, pageSize: 50 }));
         }
     }, [activeNgroupId, providers.status, users.status, dispatch]);
 
@@ -74,14 +83,48 @@ function Providers() {
         setLoading(isLoading);
     }, [providers.status, users.status]);
 
+    useEffect(() => {
+        if (!users || !users.data) return;
+
+        const page = users.page;
+
+        // avoids duplicate user calls when scrolling 
+        // Remove this page from loadingPages when it finishes
+        setLoadingPages(prev => {
+            const newSet = new Set(prev);
+            newSet.delete(page);
+            return newSet;
+        });
+
+        const newPageStart = users.cacheStart;
+        const newPageSize = users.data.length;
+
+        setMergedUsers(prev => {
+            // First load → set directly
+            if (prev.length === 0) {
+                return users.data;
+            }
+
+            // SCROLL DOWN (next page)
+            if (newPageStart > prev.length - newPageSize) {
+                return [...prev, ...users.data];
+            }
+
+            // SCROLL UP (previous page)
+            if (newPageStart < 0) {
+                return [...users.data, ...prev];
+            }
+
+            return prev; // default
+        });
+    }, [users.data]);
+
+
     const processedProviders = useMemo(() => {
         if (!providers.data || !users.data) return [];
-
-        const userMap = new Map(users.data.map(user => [user.id, user.name]));
         
         const allProvidersWithDetails = providers.data.map(provider => ({
             ...provider,
-            point_of_contact_name: provider.point_of_contact ? userMap.get(provider.point_of_contact) || 'N/A' : '',
         }));
 
         let list = [...allProvidersWithDetails];
@@ -93,11 +136,11 @@ function Providers() {
             list = list.filter(p =>
                 p.short_name?.toLowerCase().includes(lowercasedTerm) ||
                 p.long_name?.toLowerCase().includes(lowercasedTerm) ||
-                p.point_of_contact_name?.toLowerCase().includes(lowercasedTerm)
+                p.point_of_contact.name?.toLowerCase().includes(lowercasedTerm)
             );
         }
         
-        return list.sort((a, b) => {
+        list.sort((a, b) => {
             const isAsc = sorting.order === 'asc' ? 1 : -1;
             const aValue = a[sorting.orderBy];
             const bValue = b[sorting.orderBy];
@@ -106,7 +149,12 @@ function Providers() {
             if (typeof aValue === 'boolean') return (aValue === bValue ? 0 : aValue ? -1 : 1) * isAsc;
             return aValue.toString().localeCompare(bValue.toString(), undefined, { numeric: true }) * isAsc;
         });
-    }, [providers.data, users.data, sorting, searchTerm, filter]);
+
+        const startIndex = pagination.page * rowsPerPage - (providers.cacheStart ?? 0);
+        const endIndex = startIndex + rowsPerPage;
+
+        return list.slice(startIndex, endIndex);
+    }, [providers.data, users.data, sorting, searchTerm, filter, pagination.page, rowsPerPage]);
 
     const handleOpenDialog = (type, data = null) => {
         if (type === 'edit') {
@@ -128,19 +176,31 @@ function Providers() {
         }
         setIsSubmitting(true);
         try {
+            const { id, short_name, long_name, can_upload, point_of_contact, reason } = data;
+            const payload = {
+                    short_name,
+                    long_name,
+                    can_upload,
+                    point_of_contact: point_of_contact?.id || null, // send only the ID
+                    reason: can_upload ? null : reason
+            };
             if (dialog.open === 'create') {
-                const payload = { ...data, ngroup_id: activeNgroupId };
-                await providerApi.createProvider(payload);
+                await providerApi.createProvider({ ...payload, ngroup_id: activeNgroupId });
                 toast.success("Provider created successfully!");
             } else if (dialog.open === 'edit') {
-                const { id, short_name, long_name, can_upload, point_of_contact, reason } = data;
-                const updateData = { short_name, long_name, can_upload, point_of_contact, reason: can_upload ? null : reason };
-                await providerApi.updateProvider(id, updateData);
+                await providerApi.updateProvider(id, payload);
                 toast.success("Provider updated successfully");
             }
             handleCloseDialog();
             setSelected([]);
-            dispatch(fetchProviders());
+
+            if (users.page !== 1) {
+                dispatch(fetchUsers({ page: 1, pageSize: 50 }));
+            }
+
+            const apiPage = Math.floor((currentPage * rowsPerPage) / 50) + 1;
+            dispatch(fetchProviders({ page: apiPage, pageSize: 50 }));
+           
         } catch (error) {
             toast.error(parseApiError(error));
         } finally {
@@ -155,7 +215,8 @@ function Providers() {
             toast.success("Provider(s) deleted successfully!");
             setSelected([]);
             handleCloseDialog();
-            dispatch(fetchProviders());
+            const apiPage = Math.floor((currentPage * rowsPerPage) / 50) + 1;
+            dispatch(fetchProviders({ page: apiPage, pageSize: 50 }));
         } catch (error) {
             toast.error(parseApiError(error));
         } finally {
@@ -178,8 +239,45 @@ function Providers() {
         setSelected(newSelected);
     };
 
-    const handlePageChange = (event, newPage) => setPagination(prev => ({ ...prev, page: newPage }));
-    const handleRowsPerPageChange = (event) => setPagination({ ...pagination, rowsPerPage: parseInt(event.target.value, 10), page: 0 });
+    const isWithinCache = (newPage) => {
+
+        if (providers.total <= providers.cacheSize) {
+            return true;
+        }
+
+        const startIndex = newPage * rowsPerPage;// use UI rowsPerPage
+        const endIndex = startIndex + rowsPerPage;
+
+        const cacheStart = providers.cacheStart ?? 0;
+        const cacheEnd = cacheStart + (providers.cacheSize ?? 0);  // usually 50
+
+        return startIndex >= cacheStart && endIndex <= cacheEnd;
+    };
+
+    const handlePageChange = (event, newPage) => {
+         setCurrentPage(newPage); // Pagination.page gets updated
+
+        if (!isWithinCache(newPage)) {
+            const apiPageSize = 50; // chunk size
+            const startIndex = newPage * rowsPerPage;
+            const apiPage = Math.floor(startIndex / apiPageSize) + 1;
+            dispatch(fetchProviders({ page: apiPage, pageSize: apiPageSize }));
+        }
+    };
+
+    const handleRowsPerPageChange = (event) => {
+        const newSize = parseInt(event.target.value, 10);
+        setCurrentPage(0);//bring back the page to 0 when the rowsperpage change
+        
+        if (!isWithinCache(0)) {
+            console.log('yes')
+            const apiPageSize = 50; // chunk size
+            const startIndex = 0;
+            const apiPage = Math.floor(startIndex / apiPageSize) + 1;
+            dispatch(fetchProviders({ page: apiPage, pageSize: apiPageSize }));
+        }
+        setRowsPerPage(newSize);  // only update UI rows per page
+    };
     
     const handleExportProviders = async (format) => {
         const info = {
@@ -208,6 +306,45 @@ function Providers() {
     if (location.pathname !== '/providers') {
         return <Outlet key={location.pathname} />;
     }
+
+    const handleUsersScroll = (event) => {
+        const listbox = event.currentTarget;
+
+        // Scroll Down
+        if (listbox.scrollTop + listbox.clientHeight >= listbox.scrollHeight - 20) {
+
+            const nextPage = Math.floor(mergedUsers.length / users.pageSize) + 1;
+
+            // STOP if all data is loaded
+            if (mergedUsers.length >= users.total) return;
+
+            // STOP if already loaded
+            if (users.loadedPages?.includes(nextPage)) return;
+
+            // STOP if already loading
+            if (loadingPages.has(nextPage)) return;
+
+            // Mark as loading
+            setLoadingPages(prev => new Set(prev).add(nextPage));
+
+            dispatch(fetchUsers({ page: nextPage, pageSize: users.pageSize }));
+        }
+
+        // Scroll up
+        if (listbox.scrollTop === 0) {
+
+            // Stop if already at the beginning
+            if (mergedUsers.length >= users.total) return;
+
+            const previousPage = Math.max(1, users.cacheStart / users.pageSize);
+
+            // Avoid re-fetch
+            if (users.loadedPages?.includes(previousPage)) return;
+
+            dispatch(fetchUsers({ page: previousPage, pageSize: users.pageSize }));
+        }
+    };
+
 
     return (
         <Container maxWidth={false} disableGutters>
@@ -258,7 +395,7 @@ function Providers() {
                                         </TableCell>
                                     </TableRow>
                                 ) : (
-                                    processedProviders.slice(pagination.page * pagination.rowsPerPage, pagination.page * pagination.rowsPerPage + pagination.rowsPerPage).map(provider => {
+                                    processedProviders.map(provider => {
                                         const isItemSelected = selected.indexOf(provider.id) !== -1;
                                         return (
                                             <TableRow key={provider.id} hover onClick={() => handleRowClick(provider.id)} role="checkbox" tabIndex={-1} selected={isItemSelected}>
@@ -266,7 +403,7 @@ function Providers() {
                                                 <TableCell>{provider.short_name}</TableCell>
                                                 <TableCell>{provider.long_name}</TableCell>
                                                 <TableCell>{provider.can_upload ? 'Yes' : 'No'}</TableCell>
-                                                <TableCell>{provider.point_of_contact_name}</TableCell>
+                                                <TableCell>{provider.point_of_contact.name}</TableCell>
                                                 <TableCell>{provider.reason || ''}</TableCell>
                                             </TableRow>
                                         );
@@ -278,8 +415,8 @@ function Providers() {
                     <TablePagination
                         rowsPerPageOptions={[10, 25, 50]}
                         component="div"
-                        count={processedProviders.length}
-                        rowsPerPage={pagination.rowsPerPage}
+                        count={pagination.total}
+                        rowsPerPage={pagination.pageSize}
                         page={pagination.page}
                         onPageChange={handlePageChange}
                         onRowsPerPageChange={handleRowsPerPageChange}
@@ -295,7 +432,42 @@ function Providers() {
                             <>
                                 <TextField autoFocus margin="dense" name="short_name" label="Provider Short Name" fullWidth value={dialog.data.short_name} onChange={(e) => setDialog({...dialog, data: {...dialog.data, short_name: e.target.value}})} required />
                                 <TextField margin="dense" name="long_name" label="Provider Long Name" fullWidth value={dialog.data.long_name} onChange={(e) => setDialog({...dialog, data: {...dialog.data, long_name: e.target.value}})} />
-                                <Autocomplete fullWidth options={users.data} getOptionLabel={(option) => option.name} value={users.data.find(option => option.id === dialog.data.point_of_contact) || null} onChange={(e, newValue) => setDialog({...dialog, data: {...dialog.data, point_of_contact: newValue?.id || null}})} isOptionEqualToValue={(option, value) => option.id === value?.id} renderInput={(params) => (<TextField {...params} label="Point of Contact" margin="dense" />)} />
+                                <Autocomplete
+                                    fullWidth
+                                    options={mergedUsers}
+                                    getOptionLabel={(option) => option.name || ""}
+                                    isOptionEqualToValue={(option, value) => option?.id === value?.id}
+                                    
+                                    // Use cached user OR fallback to provider's existing point_of_contact
+                                    value={
+                                        mergedUsers.find(u => u.id === dialog.data.point_of_contact?.id) ||
+                                        (dialog.data.point_of_contact?.id ? dialog.data.point_of_contact : null)
+                                    }
+
+                                    ListboxProps={{ onScroll: handleUsersScroll }}
+                                    loading={users.status === 'loading'}
+
+                                    onChange={(e, newValue) => {
+                                        // Store both id and name
+                                        setDialog({
+                                            ...dialog,
+                                            data: { 
+                                                ...dialog.data, 
+                                                point_of_contact: newValue 
+                                                    ? { id: newValue.id, name: newValue.name } 
+                                                    : null 
+                                            }
+                                        });
+                                    }}
+
+                                    renderInput={(params) => (
+                                        <TextField
+                                            {...params}
+                                            label="Point of Contact"
+                                            margin="dense"
+                                        />
+                                    )}
+                                />
                                 <TextField fullWidth select label="Can Upload" name="can_upload" value={dialog.data.can_upload} onChange={(e) => setDialog({...dialog, data: {...dialog.data, can_upload: e.target.value === true }})} margin="dense">
                                     <MenuItem value={true}>Yes</MenuItem>
                                     <MenuItem value={false}>No</MenuItem>

--- a/src/pages/Providers.js
+++ b/src/pages/Providers.js
@@ -77,8 +77,10 @@ function Providers() {
 
     useEffect(() => {
         if (activeNgroupId) {
-            if (providers.status === 'idle' || !didMount.current) {
-                dispatch(fetchProviders({ page: 1, pageSize: 50 }));
+            if (!didMount.current) {
+                if (providers.status === 'idle' || providers.page !== 1){
+                    dispatch(fetchProviders({ page: 1, pageSize: 50 }));
+                }
                 didMount.current = true;
             }
             if (users.status === 'idle') dispatch(fetchUsers({ page: 1, pageSize: 50 }));

--- a/src/pages/Providers.js
+++ b/src/pages/Providers.js
@@ -68,6 +68,13 @@ function Providers() {
     const didMount = useRef(false);
     const [prevPage, setPrevPage] = useState(0);
     const wasSearching = useRef(false);
+    const [filteredProviders, setFilteredProviders] = useState({
+        data: [],
+        total: 0,
+        page: 1,
+        pageSize: 50,
+        loading: false,
+    });
     
     useEffect(() => {
         const providersMenuItems = [{ text: 'Providers', path: '/providers', icon: <AccountBoxIcon /> }];
@@ -159,16 +166,18 @@ function Providers() {
     }, [searchTerm, currentPage, prevPage]);
 
     const processedProviders = useMemo(() => {
-        if (!providers.data || !users.data) return [];
+        const sourceProviders =
+            filter === 'all'
+                ? providers.data
+                : filteredProviders.data;
+
+        if (!sourceProviders || !users.data) return [];
         
-        const allProvidersWithDetails = providers.data.map(provider => ({
-            ...provider,
+        const allProvidersWithDetails = sourceProviders.map(provider => ({
+        ...provider,
         }));
 
         let list = [...allProvidersWithDetails];
-        if (filter === 'active') list = list.filter(p => p.can_upload);
-        else if (filter === 'suspended') list = list.filter(p => !p.can_upload);
-
         if (searchTerm) {
             const lowercasedTerm = searchTerm.toLowerCase();
             list = list.filter(p =>
@@ -215,7 +224,49 @@ function Providers() {
         }
         
         return list.slice(startIndex, endIndex);
-    }, [providers.data, users.data, sorting, searchTerm, filter, pagination.page, rowsPerPage]);
+    }, [providers.data, filteredProviders.data, users.data, sorting, searchTerm, filter, pagination.page, rowsPerPage]);
+
+    useEffect(() => {
+        setCurrentPage(0);
+
+        if (filter === 'active' || filter === 'suspended') {
+            loadFilteredProviders(1);
+        }
+    }, [filter]);
+
+    const loadFilteredProviders = async (page = 1) => {
+        try {
+        setLoading(true);
+
+        const res = await providerApi.filterProviders(
+            page,
+            rowsPerPage,
+            filter === 'active',
+        );
+
+        setFilteredProviders({
+            data: res.providers,
+            total: res.total,
+            page: res.page,
+            pageSize: res.page_size,
+            loading: false,
+        });
+        } catch (err) {
+        toast.error(parseApiError(err));
+        } finally {
+        setLoading(false);
+        }
+    };
+
+    const refreshCurrentProviders = () => {
+        if (filter === 'all') {
+            const apiPage = Math.floor((currentPage * rowsPerPage) / 50) + 1;
+            dispatch(fetchProviders({ page: apiPage, pageSize: 50 }));
+        } else {
+            loadFilteredProviders(currentPage + 1);
+            dispatch(fetchProviders({ page: 1, pageSize: 50 }));
+        }
+    };
 
     const handleOpenDialog = (type, data = null) => {
         if (type === 'edit') {
@@ -259,9 +310,7 @@ function Providers() {
                 dispatch(fetchUsers({ page: 1, pageSize: 50 }));
             }
 
-            const apiPage = Math.floor((currentPage * rowsPerPage) / 50) + 1;
-            dispatch(fetchProviders({ page: apiPage, pageSize: 50 }));
-           
+            refreshCurrentProviders();
         } catch (error) {
             toast.error(parseApiError(error));
         } finally {
@@ -276,8 +325,8 @@ function Providers() {
             toast.success("Provider(s) deleted successfully!");
             setSelected([]);
             handleCloseDialog();
-            const apiPage = Math.floor((currentPage * rowsPerPage) / 50) + 1;
-            dispatch(fetchProviders({ page: apiPage, pageSize: 50 }));
+
+            refreshCurrentProviders();
         } catch (error) {
             toast.error(parseApiError(error));
         } finally {
@@ -316,7 +365,13 @@ function Providers() {
     };
 
     const handlePageChange = (event, newPage) => {
-         setCurrentPage(newPage); // Pagination.page gets updated
+        setCurrentPage(newPage); // Pagination.page gets updated
+
+        if (filter === 'active' || filter === 'suspended') {
+            loadFilteredProviders(newPage + 1); // API is 1-based
+            return;
+        }
+
 
         if (!isWithinCache(newPage)) {
             const apiPageSize = 50; // chunk size
@@ -342,28 +397,63 @@ function Providers() {
         }
         setRowsPerPage(newSize);  // only update UI rows per page
     };
-    
+
     const handleExportProviders = async (format) => {
-        const info = {
-                start: new Date().toLocaleString(),
-                end: new Date().toLocaleString()
-        };
         if (format !== 'pdf') return;
+
         try {
-            const suspended = processedProviders.filter(p => !p.can_upload);
-            if (suspended.length === 0) {
-                toast.info("There are no suspended providers to export based on current filters.");
+            const pageSize = 50;
+            let page = 1;
+            let total = 0;
+            let allSuspended = [];
+
+            do {
+                const res = await providerApi.filterProviders(
+                    page,
+                    pageSize,
+                    false
+                );
+
+                const providers = res.providers || [];
+                total = res.total ?? 0;
+
+                allSuspended = allSuspended.concat(providers);
+                page += 1;
+
+            } while (allSuspended.length < total);
+
+            if (allSuspended.length === 0) {
+                toast.info("There are no suspended providers to export.");
                 return;
             }
+
+            const info = {
+                start: new Date().toLocaleString(),
+                end: new Date().toLocaleString(),
+            };
+
             const columns = [
                 { header: "Short Name", dataKey: "short_name" },
                 { header: "Long Name", dataKey: "long_name" },
                 { header: "Point of Contact", dataKey: "point_of_contact_name" },
                 { header: "Reason", dataKey: "reason" },
             ];
-            generatePDFReport("Suspended Providers Report", columns, suspended, null, info);
+
+            generatePDFReport(
+                "Suspended Providers Report",
+                columns,
+                allSuspended.map(p => ({
+                    ...p,
+                    point_of_contact_name: p.point_of_contact?.name || "",
+                })),
+                null,
+                info
+            );
+
         } catch (err) {
-            toast.error("Failed to export suspended providers: " + parseApiError(err));
+            toast.error(
+                "Failed to export suspended providers: " + parseApiError(err)
+            );
         }
     };
 
@@ -479,7 +569,7 @@ function Providers() {
                     <TablePagination
                         rowsPerPageOptions={[10, 25, 50]}
                         component="div"
-                        count={searchTerm || filter !== 'all' ? filteredCount : pagination.total}
+                        count={filter === 'all'? (searchTerm ? filteredCount : pagination.total): filteredProviders.total}
                         rowsPerPage={pagination.pageSize}
                         page={pagination.page}
                         onPageChange={handlePageChange}

--- a/src/pages/Providers.js
+++ b/src/pages/Providers.js
@@ -270,7 +270,6 @@ function Providers() {
         setCurrentPage(0);//bring back the page to 0 when the rowsperpage change
         
         if (!isWithinCache(0)) {
-            console.log('yes')
             const apiPageSize = 50; // chunk size
             const startIndex = 0;
             const apiPage = Math.floor(startIndex / apiPageSize) + 1;

--- a/src/pages/Users.js
+++ b/src/pages/Users.js
@@ -85,8 +85,10 @@ function Users() {
     // "Smart" data fetching that uses the cache
     useEffect(() => {
         if (activeNgroupId) {
-            if (users.status === 'idle' || !didMount.current) {
-                dispatch(fetchUsers({ page: 1, pageSize: 50 }));
+            if (!didMount.current) {
+                if (users.status === 'idle' || users.page !== 1){
+                    dispatch(fetchUsers({ page: 1, pageSize: 50 }));
+                }
                 didMount.current = true;
             }
             if (roles.status === 'idle') dispatch(fetchRoles());

--- a/src/pages/Users.js
+++ b/src/pages/Users.js
@@ -70,6 +70,8 @@ function Users() {
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [filteredCount, setFilteredCount] = useState(0);
     const didMount = useRef(false);
+    const [prevPage, setPrevPage] = useState(0);
+    const wasSearching = useRef(false);
     
     useEffect(() => {
         const usersMenuItems = [
@@ -110,6 +112,23 @@ function Users() {
             setCurrentPage(0);
         }
     }, [activeNgroupId, users.total]);
+
+    useEffect(() => {
+        const isSearching = searchTerm.trim() !== "";
+
+        if (isSearching && !wasSearching.current) {
+            // Search just started — store page ONCE
+            setPrevPage(currentPage);
+            setCurrentPage(0);
+        }
+
+        if (!isSearching && wasSearching.current) {
+            // Search just ended — restore ONCE
+            setCurrentPage(prevPage);
+        }
+
+        wasSearching.current = isSearching;
+    }, [searchTerm, currentPage, prevPage]);
 
     const processedUsers = useMemo(() => {
         if (!users.data || !roles.data || !providers.data) return [];
@@ -157,19 +176,18 @@ function Users() {
         }
         
         let startIndex, endIndex;
-        // Prevent negative or out-of-range pages
-        const safePage = Math.max(
-            0,
-            Math.min(
-                currentPage,
-                Math.floor((filtered.length - 1) / rowsPerPage)  // max valid page
-            )
-        );
 
         if (searchTerm) {
             // SCENARIO 1: SEARCHING/FILTERING
             // List contains the *entire* locally filtered/sorted set.
-            startIndex = safePage * rowsPerPage;
+            const maxFilteredPage = Math.max(
+                0,
+                Math.floor((filtered.length - 1) / rowsPerPage)
+            );
+
+            const safeSearchPage = Math.min(currentPage, maxFilteredPage);
+
+            startIndex = safeSearchPage * rowsPerPage;
             endIndex = startIndex + rowsPerPage;
         } else {
             // SCENARIO 2: NORMAL VIEW (PAGINATING THROUGH CACHE CHUNKS)
@@ -307,8 +325,10 @@ function Users() {
         if (!isWithinCache(newPage)) {
             const apiPageSize = 50; // chunk size
             const startIndex = newPage * rowsPerPage;
-            const apiPage = Math.floor(startIndex / apiPageSize) + 1;
-            dispatch(fetchUsers({ page: apiPage, pageSize: apiPageSize }));
+            if (!searchTerm){
+                const apiPage = Math.floor(startIndex / apiPageSize) + 1;
+                dispatch(fetchUsers({ page: apiPage, pageSize: apiPageSize }));
+            }
         }
     };
 
@@ -319,8 +339,10 @@ function Users() {
         if (!isWithinCache(0)) {
             const apiPageSize = 50; // chunk size
             const startIndex = 0;
-            const apiPage = Math.floor(startIndex / apiPageSize) + 1;
-            dispatch(fetchUsers({ page: apiPage, pageSize: apiPageSize }));
+            if (!searchTerm){
+                const apiPage = Math.floor(startIndex / apiPageSize) + 1;
+                dispatch(fetchUsers({ page: apiPage, pageSize: apiPageSize }));
+            }
         }
         setRowsPerPage(newSize);  // only update UI rows per page
     };

--- a/src/pages/Users.js
+++ b/src/pages/Users.js
@@ -69,6 +69,7 @@ function Users() {
     const [dialog, setDialog] = useState({ open: null, data: null });
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [filteredCount, setFilteredCount] = useState(0);
+    const [initialLoadComplete, setInitialLoadComplete] = useState(false);
     
     useEffect(() => {
         const usersMenuItems = [
@@ -82,7 +83,10 @@ function Users() {
     // "Smart" data fetching that uses the cache
     useEffect(() => {
         if (activeNgroupId) {
-            if (users.status === 'idle') dispatch(fetchUsers({ page: 1, pageSize: 50 }));
+            if (users.status === 'idle' || (!initialLoadComplete && users.page !== 1)) {
+                dispatch(fetchUsers({ page: 1, pageSize: 50 }));
+                setInitialLoadComplete(true);
+            }
             if (roles.status === 'idle') dispatch(fetchRoles());
             if (providers.status === 'idle') dispatch(fetchProviders({ page: 1, pageSize: 50 }));
         }
@@ -97,6 +101,15 @@ function Users() {
     useEffect(() => {
         setCurrentPage(0);
     }, [searchTerm]);
+
+    useEffect(() => {
+        const maxPage = Math.floor((users.total - 1) / rowsPerPage) || 0;
+
+        // if currentPage is invalid, reset to 0
+        if (currentPage > maxPage) {
+            setCurrentPage(0);
+        }
+    }, [activeNgroupId, users.total]);
 
     const processedUsers = useMemo(() => {
         if (!users.data || !roles.data || !providers.data) return [];

--- a/src/pages/Users.js
+++ b/src/pages/Users.js
@@ -57,7 +57,13 @@ function Users() {
     // Local state for UI operations
     const [loading, setLoading] = useState(true);
     const [selected, setSelected] = useState([]);
-    const [pagination, setPagination] = useState({ page: 0, rowsPerPage: 10 });
+    const [rowsPerPage, setRowsPerPage] = useState(10);
+    const [currentPage, setCurrentPage] = useState(0); // 0-based for MUI TablePagination
+    const pagination = {
+        page: currentPage,
+        pageSize: rowsPerPage,
+        total: users.total ?? 0
+    };
     const [searchTerm, setSearchTerm] = useState('');
     const [sorting, setSorting] = useState({ orderBy: 'name', order: 'asc' });
     const [dialog, setDialog] = useState({ open: null, data: null });
@@ -75,9 +81,9 @@ function Users() {
     // "Smart" data fetching that uses the cache
     useEffect(() => {
         if (activeNgroupId) {
-            if (users.status === 'idle') dispatch(fetchUsers());
+            if (users.status === 'idle') dispatch(fetchUsers({ page: 1, pageSize: 50 }));
             if (roles.status === 'idle') dispatch(fetchRoles());
-            if (providers.status === 'idle') dispatch(fetchProviders());
+            if (providers.status === 'idle') dispatch(fetchProviders({ page: 1, pageSize: 50 }));
         }
     }, [activeNgroupId, users.status, roles.status, providers.status, dispatch]);
 
@@ -114,7 +120,7 @@ function Users() {
             );
         }
 
-        return filtered.sort((a, b) => {
+        filtered.sort((a, b) => {
             const isAsc = sorting.order === 'asc' ? 1 : -1;
             let aValue = a[sorting.orderBy];
             let bValue = b[sorting.orderBy];
@@ -126,7 +132,11 @@ function Users() {
             if (bValue === null || bValue === undefined) return -1 * isAsc;
             return aValue.toString().localeCompare(bValue.toString()) * isAsc;
         });
-    }, [users.data, roles.data, providers.data, sorting, searchTerm]);
+        const startIndex = pagination.page * rowsPerPage - (users.cacheStart ?? 0);
+        const endIndex = startIndex + rowsPerPage;
+
+        return filtered.slice(startIndex, endIndex);
+    }, [users.data, roles.data, providers.data, sorting, searchTerm, pagination.page, rowsPerPage]);
 
     const handleClick = useCallback((id) => {
         const selectedIndex = selected.indexOf(id);
@@ -155,7 +165,6 @@ function Users() {
             );
         }
         return processedUsers
-            .slice(pagination.page * pagination.rowsPerPage, pagination.page * pagination.rowsPerPage + pagination.rowsPerPage)
             .map((user) => {
                 const isItemSelected = selected.indexOf(user.id) !== -1;
                 const isManageable = canModifyUser(currentUser, user);
@@ -193,7 +202,8 @@ function Users() {
             await assignUserRole(dialog.data.id, dialog.data.role.id);
             toast.success("User role updated successfully!");
             handleCloseDialog();
-            dispatch(fetchUsers());
+            const apiPage = Math.floor((currentPage * rowsPerPage) / 50) + 1;
+            dispatch(fetchUsers({ page: apiPage, pageSize: 50 }));
             setSelected([]);
         } catch (error) {
             toast.error(parseApiError(error));
@@ -209,7 +219,8 @@ function Users() {
             toast.success("User(s) deleted successfully!");
             setSelected([]);
             handleCloseDialog();
-            dispatch(fetchUsers());
+            const apiPage = Math.floor((currentPage * rowsPerPage) / 50) + 1;
+            dispatch(fetchUsers({ page: apiPage, pageSize: 50 }));
         } catch (error) {
             toast.error(parseApiError(error));
         } finally {
@@ -232,6 +243,47 @@ function Users() {
         }
         setSelected([]);
     };
+
+     const isWithinCache = (newPage) => {
+
+        if (users.total <= users.cacheSize) {
+            return true;
+        }
+
+        const startIndex = newPage * rowsPerPage;// use UI rowsPerPage
+        const endIndex = startIndex + rowsPerPage;
+
+        const cacheStart = users.cacheStart ?? 0;
+        const cacheEnd = cacheStart + (users.cacheSize ?? 0);  // usually 50
+
+        return startIndex >= cacheStart && endIndex <= cacheEnd;
+    };
+
+    const handlePageChange = (event, newPage) => {
+         setCurrentPage(newPage); // Pagination.page gets updated
+
+        if (!isWithinCache(newPage)) {
+            const apiPageSize = 50; // chunk size
+            const startIndex = newPage * rowsPerPage;
+            const apiPage = Math.floor(startIndex / apiPageSize) + 1;
+            dispatch(fetchUsers({ page: apiPage, pageSize: apiPageSize }));
+        }
+    };
+
+    const handleRowsPerPageChange = (event) => {
+        const newSize = parseInt(event.target.value, 10);
+        setCurrentPage(0);//bring back the page to 0 when the rowsperpage change
+        
+        if (!isWithinCache(0)) {
+            console.log('yes')
+            const apiPageSize = 50; // chunk size
+            const startIndex = 0;
+            const apiPage = Math.floor(startIndex / apiPageSize) + 1;
+            dispatch(fetchUsers({ page: apiPage, pageSize: apiPageSize }));
+        }
+        setRowsPerPage(newSize);  // only update UI rows per page
+    };
+
     
     if (location.pathname !== '/users') {
         return <Outlet key={location.pathname} />;
@@ -275,11 +327,11 @@ function Users() {
                     <TablePagination
                         rowsPerPageOptions={[10, 25, 50]}
                         component="div"
-                        count={processedUsers.length}
-                        rowsPerPage={pagination.rowsPerPage}
+                        count={pagination.total}
+                        rowsPerPage={pagination.pageSize}
                         page={pagination.page}
-                        onPageChange={(e, newPage) => setPagination(prev => ({ ...prev, page: newPage }))}
-                        onRowsPerPageChange={(e) => setPagination({ rowsPerPage: parseInt(e.target.value, 10), page: 0 })}
+                        onPageChange={handlePageChange}
+                        onRowsPerPageChange={handleRowsPerPageChange}
                     />
                 </CardContent>
             </Card>

--- a/src/pages/Users.js
+++ b/src/pages/Users.js
@@ -68,6 +68,7 @@ function Users() {
     const [sorting, setSorting] = useState({ orderBy: 'name', order: 'asc' });
     const [dialog, setDialog] = useState({ open: null, data: null });
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [filteredCount, setFilteredCount] = useState(0);
     
     useEffect(() => {
         const usersMenuItems = [
@@ -92,6 +93,10 @@ function Users() {
         const isLoading = users.status === 'loading' || roles.status === 'loading' || providers.status === 'loading';
         setLoading(isLoading);
     }, [users.status, roles.status, providers.status]);
+
+    useEffect(() => {
+        setCurrentPage(0);
+    }, [searchTerm]);
 
     const processedUsers = useMemo(() => {
         if (!users.data || !roles.data || !providers.data) return [];
@@ -132,8 +137,32 @@ function Users() {
             if (bValue === null || bValue === undefined) return -1 * isAsc;
             return aValue.toString().localeCompare(bValue.toString()) * isAsc;
         });
-        const startIndex = pagination.page * rowsPerPage - (users.cacheStart ?? 0);
-        const endIndex = startIndex + rowsPerPage;
+        const newFilteredCount = filtered.length;
+
+        if (newFilteredCount !== filteredCount) {
+            setFilteredCount(newFilteredCount);
+        }
+        
+        let startIndex, endIndex;
+        // Prevent negative or out-of-range pages
+        const safePage = Math.max(
+            0,
+            Math.min(
+                currentPage,
+                Math.floor((filtered.length - 1) / rowsPerPage)  // max valid page
+            )
+        );
+
+        if (searchTerm) {
+            // SCENARIO 1: SEARCHING/FILTERING
+            // List contains the *entire* locally filtered/sorted set.
+            startIndex = safePage * rowsPerPage;
+            endIndex = startIndex + rowsPerPage;
+        } else {
+            // SCENARIO 2: NORMAL VIEW (PAGINATING THROUGH CACHE CHUNKS)
+            startIndex = Math.max(0, pagination.page * rowsPerPage - (users.cacheStart ?? 0));
+            endIndex = Math.min(filtered.length, startIndex + rowsPerPage);
+        }
 
         return filtered.slice(startIndex, endIndex);
     }, [users.data, roles.data, providers.data, sorting, searchTerm, pagination.page, rowsPerPage]);
@@ -275,7 +304,6 @@ function Users() {
         setCurrentPage(0);//bring back the page to 0 when the rowsperpage change
         
         if (!isWithinCache(0)) {
-            console.log('yes')
             const apiPageSize = 50; // chunk size
             const startIndex = 0;
             const apiPage = Math.floor(startIndex / apiPageSize) + 1;
@@ -327,7 +355,7 @@ function Users() {
                     <TablePagination
                         rowsPerPageOptions={[10, 25, 50]}
                         component="div"
-                        count={pagination.total}
+                        count={searchTerm ? filteredCount : pagination.total}
                         rowsPerPage={pagination.pageSize}
                         page={pagination.page}
                         onPageChange={handlePageChange}

--- a/src/pages/Users.js
+++ b/src/pages/Users.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'; // UPDATED: Restored useCallback
 import {
     Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
     Paper, Button, Typography, Checkbox, TablePagination, Dialog, DialogTitle,
@@ -69,7 +69,7 @@ function Users() {
     const [dialog, setDialog] = useState({ open: null, data: null });
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [filteredCount, setFilteredCount] = useState(0);
-    const [initialLoadComplete, setInitialLoadComplete] = useState(false);
+    const didMount = useRef(false);
     
     useEffect(() => {
         const usersMenuItems = [
@@ -83,9 +83,9 @@ function Users() {
     // "Smart" data fetching that uses the cache
     useEffect(() => {
         if (activeNgroupId) {
-            if (users.status === 'idle' || (!initialLoadComplete && users.page !== 1)) {
+            if (users.status === 'idle' || !didMount.current) {
                 dispatch(fetchUsers({ page: 1, pageSize: 50 }));
-                setInitialLoadComplete(true);
+                didMount.current = true;
             }
             if (roles.status === 'idle') dispatch(fetchRoles());
             if (providers.status === 'idle') dispatch(fetchProviders({ page: 1, pageSize: 50 }));

--- a/src/pages/metrics/MetricsFilter.js
+++ b/src/pages/metrics/MetricsFilter.js
@@ -24,6 +24,24 @@ import {
 
 const getDefaultStartDate = () => dayjs().subtract(7, 'day');
 const getDefaultEndDate = () => dayjs();
+const OPTION_PAGE_SIZE = 50;
+// Keeps all previously loaded autocomplete pages available while navigating
+// between metrics screens, since the shared Redux cache only stores one page.
+const metricsFilterOptionCache = new Map();
+
+const getEmptyOptionCache = () => ({
+  providers: [],
+  users: [],
+  collections: [],
+});
+
+const getOptionCacheForNgroup = (ngroupId) => {
+  if (!ngroupId) {
+    return getEmptyOptionCache();
+  }
+
+  return metricsFilterOptionCache.get(ngroupId) || getEmptyOptionCache();
+};
 
 function MetricsFilter({ onApplyFilters, onClearFilters, isDataLoading }) {
   const dispatch = useDispatch();
@@ -36,28 +54,157 @@ function MetricsFilter({ onApplyFilters, onClearFilters, isDataLoading }) {
     collections 
   } = useSelector((state) => state.dataCache);
 
-  const loadingOptions = providers.status === 'loading' || users.status === 'loading' || collections.status === 'loading';
-
+  const [mergedProviders, setMergedProviders] = useState(() => getOptionCacheForNgroup(activeNgroupId).providers);
+  const [mergedUsers, setMergedUsers] = useState(() => getOptionCacheForNgroup(activeNgroupId).users);
+  const [mergedCollections, setMergedCollections] = useState(() => getOptionCacheForNgroup(activeNgroupId).collections);
+  const [providerLoadingPages, setProviderLoadingPages] = useState(new Set());
+  const [userLoadingPages, setUserLoadingPages] = useState(new Set());
+  const [collectionLoadingPages, setCollectionLoadingPages] = useState(new Set());
+  const [providerOpen, setProviderOpen] = useState(false);
+  const [userOpen, setUserOpen] = useState(false);
+  const [collectionOpen, setCollectionOpen] = useState(false);
   const [selectedProvider, setSelectedProvider] = useState(null);
   const [selectedUser, setSelectedUser] = useState(null);
   const [selectedCollection, setSelectedCollection] = useState(null);
   const [startDate, setStartDate] = useState(getDefaultStartDate);
   const [endDate, setEndDate] = useState(getDefaultEndDate);
 
+  const loadingOptions = providers.status === 'loading' || users.status === 'loading' || collections.status === 'loading';
+  const isInitialOptionsLoading =
+    (providers.status === 'loading' && mergedProviders.length === 0) ||
+    (users.status === 'loading' && mergedUsers.length === 0) ||
+    (collections.status === 'loading' && mergedCollections.length === 0);
+
   useEffect(() => {
-    // Fetch each data type only if it hasn't been fetched yet for this session
     if (activeNgroupId) {
-        if (providers.status === 'idle') {
-            dispatch(fetchProviders());
-        }
-        if (users.status === 'idle') {
-            dispatch(fetchUsers());
-        }
-        if (collections.status === 'idle') {
-            dispatch(fetchCollections());
-        }
+      if (providers.status === 'idle') {
+        dispatch(fetchProviders({ page: 1, pageSize: OPTION_PAGE_SIZE }));
+      }
+      if (users.status === 'idle') {
+        dispatch(fetchUsers({ page: 1, pageSize: OPTION_PAGE_SIZE }));
+      }
+      if (collections.status === 'idle') {
+        dispatch(fetchCollections({ page: 1, pageSize: OPTION_PAGE_SIZE }));
+      }
     }
   }, [activeNgroupId, providers.status, users.status, collections.status, dispatch]);
+
+  useEffect(() => {
+    if (!activeNgroupId) {
+      setMergedProviders([]);
+      setMergedUsers([]);
+      setMergedCollections([]);
+      setProviderLoadingPages(new Set());
+      setUserLoadingPages(new Set());
+      setCollectionLoadingPages(new Set());
+      setProviderOpen(false);
+      setUserOpen(false);
+      setCollectionOpen(false);
+      return;
+    }
+
+    // Rehydrate previously scrolled options when this filter remounts on
+    // another metrics page, so the dropdown doesn't collapse back to one page.
+    const cachedOptions = getOptionCacheForNgroup(activeNgroupId);
+    setMergedProviders(cachedOptions.providers);
+    setMergedUsers(cachedOptions.users);
+    setMergedCollections(cachedOptions.collections);
+  }, [activeNgroupId]);
+
+  useEffect(() => {
+    if (!providers.data) return;
+
+    setProviderLoadingPages((prev) => {
+      const newSet = new Set(prev);
+      newSet.delete(providers.page);
+      return newSet;
+    });
+
+    setMergedProviders((prev) => {
+      const mergedMap = new Map(prev.map((item) => [item.id, item]));
+      providers.data.forEach((item) => mergedMap.set(item.id, item));
+      const nextProviders = Array.from(mergedMap.values());
+      // Persist the merged list outside component state so other metrics pages
+      // can reuse everything loaded so far.
+      metricsFilterOptionCache.set(activeNgroupId, {
+        ...getOptionCacheForNgroup(activeNgroupId),
+        providers: nextProviders,
+      });
+      return nextProviders;
+    });
+  }, [providers.data, providers.page, activeNgroupId]);
+
+  useEffect(() => {
+    if (!users.data) return;
+
+    setUserLoadingPages((prev) => {
+      const newSet = new Set(prev);
+      newSet.delete(users.page);
+      return newSet;
+    });
+
+    setMergedUsers((prev) => {
+      const mergedMap = new Map(prev.map((item) => [item.id, item]));
+      users.data.forEach((item) => mergedMap.set(item.id, item));
+      const nextUsers = Array.from(mergedMap.values());
+      // Persist the merged list outside component state so other metrics pages
+      // can reuse everything loaded so far.
+      metricsFilterOptionCache.set(activeNgroupId, {
+        ...getOptionCacheForNgroup(activeNgroupId),
+        users: nextUsers,
+      });
+      return nextUsers;
+    });
+  }, [users.data, users.page, activeNgroupId]);
+
+  useEffect(() => {
+    if (!collections.data) return;
+
+    setCollectionLoadingPages((prev) => {
+      const newSet = new Set(prev);
+      newSet.delete(collections.page);
+      return newSet;
+    });
+
+    setMergedCollections((prev) => {
+      const mergedMap = new Map(prev.map((item) => [item.id, item]));
+      collections.data.forEach((item) => mergedMap.set(item.id, item));
+      const nextCollections = Array.from(mergedMap.values());
+      // Persist the merged list outside component state so other metrics pages
+      // can reuse everything loaded so far.
+      metricsFilterOptionCache.set(activeNgroupId, {
+        ...getOptionCacheForNgroup(activeNgroupId),
+        collections: nextCollections,
+      });
+      return nextCollections;
+    });
+  }, [collections.data, collections.page, activeNgroupId]);
+
+  const handleAutocompleteScroll = (event, entityState, mergedData, loadingPages, setLoadingPages, fetchAction) => {
+    const listbox = event.currentTarget;
+    const atBottom = listbox.scrollTop + listbox.clientHeight >= listbox.scrollHeight - 20;
+
+    if (!atBottom) return;
+    if (mergedData.length >= entityState.total) return;
+
+    // Ask the shared cache for the next backend page, then merge that page into
+    // the local session list when it arrives.
+    const nextPage = Math.floor(mergedData.length / entityState.pageSize) + 1;
+    if (loadingPages.has(nextPage)) return;
+
+    setLoadingPages((prev) => new Set(prev).add(nextPage));
+    dispatch(fetchAction({ page: nextPage, pageSize: entityState.pageSize || OPTION_PAGE_SIZE }));
+  };
+
+  const handleAutocompleteClose = (setOpen, loadingPages) => (event, reason) => {
+    // Ignore blur closes during infinite-scroll fetches so the dropdown stays
+    // open while the next page is appended.
+    if (reason === 'blur' && loadingPages.size > 0) {
+      return;
+    }
+
+    setOpen(false);
+  };
 
   const handleApplyClick = () => {
     const filters = {
@@ -116,43 +263,88 @@ function MetricsFilter({ onApplyFilters, onClearFilters, isDataLoading }) {
           <Grid item sx={{ flexGrow: 1, minWidth: '200px' }}>
             <Autocomplete
               fullWidth
-              options={providers.data}
+              open={providerOpen}
+              onOpen={() => setProviderOpen(true)}
+              onClose={handleAutocompleteClose(setProviderOpen, providerLoadingPages)}
+              options={mergedProviders}
               getOptionLabel={(o) => o.short_name || ''}
               value={selectedProvider}
               onChange={(e, v) => setSelectedProvider(v)}
               isOptionEqualToValue={(o, v) => o.id === v.id}
+              ListboxProps={{
+                onScroll: (event) =>
+                  handleAutocompleteScroll(
+                    event,
+                    providers,
+                    mergedProviders,
+                    providerLoadingPages,
+                    setProviderLoadingPages,
+                    fetchProviders
+                  ),
+              }}
               renderInput={(params) => (
                 <TextField {...params} label="Provider" size="small" />
               )}
-              disabled={loadingOptions || !activeNgroupId}
+              loading={providers.status === 'loading' && mergedProviders.length > 0}
+              disabled={isInitialOptionsLoading || !activeNgroupId}
             />
           </Grid>
           <Grid item sx={{ flexGrow: 1, minWidth: '200px' }}>
             <Autocomplete
               fullWidth
-              options={users.data}
+              open={userOpen}
+              onOpen={() => setUserOpen(true)}
+              onClose={handleAutocompleteClose(setUserOpen, userLoadingPages)}
+              options={mergedUsers}
               getOptionLabel={(o) => o.name || ''}
               value={selectedUser}
               onChange={(e, v) => setSelectedUser(v)}
               isOptionEqualToValue={(o, v) => o.id === v.id}
+              ListboxProps={{
+                onScroll: (event) =>
+                  handleAutocompleteScroll(
+                    event,
+                    users,
+                    mergedUsers,
+                    userLoadingPages,
+                    setUserLoadingPages,
+                    fetchUsers
+                  ),
+              }}
               renderInput={(params) => (
                 <TextField {...params} label="User" size="small" />
               )}
-              disabled={loadingOptions || !activeNgroupId}
+              loading={users.status === 'loading' && mergedUsers.length > 0}
+              disabled={isInitialOptionsLoading || !activeNgroupId}
             />
           </Grid>
           <Grid item sx={{ flexGrow: 1, minWidth: '200px' }}>
             <Autocomplete
               fullWidth
-              options={collections.data}
+              open={collectionOpen}
+              onOpen={() => setCollectionOpen(true)}
+              onClose={handleAutocompleteClose(setCollectionOpen, collectionLoadingPages)}
+              options={mergedCollections}
               getOptionLabel={(o) => o.short_name || ''}
               value={selectedCollection}
               onChange={(e, v) => setSelectedCollection(v)}
               isOptionEqualToValue={(o, v) => o.id === v.id}
+              ListboxProps={{
+                onScroll: (event) =>
+                  handleAutocompleteScroll(
+                    event,
+                    collections,
+                    mergedCollections,
+                    collectionLoadingPages,
+                    setCollectionLoadingPages,
+                    fetchCollections
+                  ),
+              }}
               renderInput={(params) => (
                 <TextField {...params} label="Collection" size="small" />
               )}
-              disabled={loadingOptions || !activeNgroupId}
+              loading={collections.status === 'loading' && mergedCollections.length > 0}
+              disabled={isInitialOptionsLoading || !activeNgroupId}
             />
           </Grid>
         </Grid>


### PR DESCRIPTION
Enhancement: Pagination Support Added for Users, Collections, Egress, and Providers

This update introduces full pagination support across all four modules — Users, Collections, Egress, and Providers — along with an improved caching strategy.

Key Behavior Changes

Optimized Caching (Max 50 Items)
The client now caches only the first 50 entries by default.
Additional entries are fetched and cached on demand when the user navigates to pages beyond the initial 50.
The cache window remains capped at 50 items, and shifts based on the user's current page selection.

Search Behavior Updated
Search now operates only within the currently cached 50-item window.
Example:
If the user is viewing items 51–60, the cache contains entries 51–100, and the search will only filter within that range.
This avoids unnecessary API calls and keeps search results consistent with what the user is currently browsing.