### PR TITLE
Feature: support provider update when user approval

### DIFF
--- a/src/api/userApplicationApi.js
+++ b/src/api/userApplicationApi.js
@@ -60,9 +60,11 @@ export const listUserApplications = (status, options = {}) => {
  * Approves a user application. Requires 'approve_user' privilege.
  * @param {string} applicationId - The UUID of the application.
  * @param {string} roleId - The UUID of the role to assign.
+ * @param {string} [providerId] - The UUID of the provider to assign (optional).
  */
-export const approveUserApplication = (applicationId, roleId) => {
-    return apiClient.post(`/user_application/${applicationId}/approve?role_id=${roleId}`);
+export const approveUserApplication = (applicationId, roleId, providerId = null) => {
+    const query = providerId ? `?role_id=${roleId}&provider_id=${providerId}` : `?role_id=${roleId}`;
+    return apiClient.post(`/user_application/${applicationId}/approve${query}`);
 };
 
 /**

--- a/src/app/reducers/dataCacheSlice.js
+++ b/src/app/reducers/dataCacheSlice.js
@@ -12,7 +12,7 @@ import { listCueusers } from '../../api/cueUser';
 
 export const fetchProviders = createAsyncThunk(
   'dataCache/fetchProviders',
-  async ({ page, pageSize }, { rejectWithValue }) => {
+  async ({ page = 1, pageSize = 50 } = {}, { rejectWithValue }) => {
     try {
       const response = await providerApi.listProviders(page, pageSize);
       response.cacheStart = (page - 1) * pageSize;

--- a/src/config.js
+++ b/src/config.js
@@ -40,7 +40,7 @@ export const config = {
     ...envConfig,
 
     // Static settings that are the same across all environments
-    version: "0.0.53",
+    version: "0.0.54",
     keycloakRealm: "cue",
 };
 

--- a/src/pages/users/PendingRequests.js
+++ b/src/pages/users/PendingRequests.js
@@ -51,6 +51,70 @@ function PendingRequests() {
     const [order, setOrder] = useState('asc');
     const [orderBy, setOrderBy] = useState('name');
 
+    const [mergedProviders, setMergedProviders] = useState([]);
+    const [providerLoadingPages, setProviderLoadingPages] = useState(new Set());
+
+    useEffect(() => {
+        const page = providers.page;
+        // Remove this page from loadingPages when it finishes
+        setProviderLoadingPages(prev => {
+            const newSet = new Set(prev);
+            newSet.delete(page);
+            return newSet;
+        });
+
+        const newPageStart = providers.cacheStart;
+        const newPageSize = providers.data.length;
+
+        setMergedProviders(prev => {
+            // First load → set directly
+            if (prev.length === 0) {
+                return providers.data;
+            }
+
+            // SCROLL DOWN (next page)
+            if (newPageStart > prev.length - newPageSize) {
+                return [...prev, ...providers.data];
+            }
+
+            // SCROLL UP (previous page)
+            if (newPageStart < 0) {
+                return [...providers.data, ...prev];
+            }
+
+            return prev; // default
+        });
+    }, [providers.data, providers.page, providers.cacheStart]);
+
+    const handleProvidersScroll = (event) => {
+        const listbox = event.currentTarget;
+
+        // Scroll Down
+        if (listbox.scrollTop + listbox.clientHeight >= listbox.scrollHeight - 20) {
+            const nextPage = Math.floor(mergedProviders.length / providers.pageSize) + 1;
+
+            // STOP if all data is loaded
+            if (mergedProviders.length >= providers.total) return;
+
+            // STOP if already loading
+            if (providerLoadingPages.has(nextPage)) return;
+
+            // Mark as loading
+            setProviderLoadingPages(prev => new Set(prev).add(nextPage));
+
+            dispatch(fetchProviders({ page: nextPage, pageSize: providers.pageSize }));
+        }
+
+        // Scroll up
+        if (listbox.scrollTop === 0) {
+            if (mergedProviders.length >= providers.total) return;
+
+            const previousPage = Math.max(1, providers.cacheStart / providers.pageSize);
+
+            dispatch(fetchProviders({ page: previousPage, pageSize: providers.pageSize }));
+        }
+    };
+
     // --- Check if the user is an admin or security user ---
     const isPrivilegedViewer = useMemo(() =>
         currentUser?.roles?.includes('admin') || currentUser?.roles?.includes('security'),
@@ -60,7 +124,7 @@ function PendingRequests() {
     useEffect(() => {
         // Fetch dependencies regardless of activeNgroupId, since privileged users don't need one
         if (roles.status === 'idle') dispatch(fetchRoles());
-        if (providers.status === 'idle') dispatch(fetchProviders());
+        if (providers.status === 'idle') dispatch(fetchProviders({ page: 1, pageSize: 50 }));
     }, [roles.status, providers.status, dispatch]);
 
     const fetchPageData = useCallback(async () => {
@@ -141,7 +205,10 @@ function PendingRequests() {
     const handleOpenDialog = (type) => {
         if (type === 'accept') {
             const app = processedApps.find(a => a.id === selected[0]);
-            setDialog({ open: 'accept', data: { ...app, role: null } });
+            const initialProvider = app.provider_id
+                ? (providers.data.find(p => p.id === app.provider_id) || { id: app.provider_id, short_name: app.providerName || '' })
+                : null;
+            setDialog({ open: 'accept', data: { ...app, role: null, selectedProvider: initialProvider } });
         } else {
             setRejectMarkAsSpam(false);
             setDialog({ open: 'reject', data: null });
@@ -157,9 +224,14 @@ function PendingRequests() {
             toast.error("Please select a role for the user.");
             return;
         }
+        if (dialog.data.role.short_name === 'provider' && !dialog.data.selectedProvider) {
+            toast.error("A provider must be selected for the provider role.");
+            return;
+        }
         setActionLoading(true);
         try {
-            await approveUserApplication(dialog.data.id, dialog.data.role.id);
+            const providerId = dialog.data.role.short_name === 'provider' ? dialog.data.selectedProvider.id : null;
+            await approveUserApplication(dialog.data.id, dialog.data.role.id, providerId);
             handleCloseDialog();
             setSelected([]);
             
@@ -277,10 +349,23 @@ function PendingRequests() {
                     <Autocomplete
                         options={getEditableRoles(roles.data, currentUser?.roles)}
                         getOptionLabel={(option) => option.long_name}
-                        onChange={(e, newValue) => setDialog(prev => ({ ...prev, data: { ...prev.data, role: newValue } }))}
+                        value={dialog.data?.role || null}
+                        onChange={(e, newValue) => setDialog(prev => ({ ...prev, data: { ...prev.data, role: newValue, selectedProvider: newValue?.short_name === 'provider' ? prev.data.selectedProvider : null } }))}
                         renderInput={(params) => <TextField {...params} label="Role" margin="dense" fullWidth />}
                         isOptionEqualToValue={(option, value) => option.id === value.id}
                     />
+                    {dialog.data?.role?.short_name === 'provider' && (
+                        <Autocomplete
+                            options={mergedProviders || []}
+                            getOptionLabel={(option) => option.short_name || ""}
+                            value={dialog.data?.selectedProvider || null}
+                            onChange={(event, newValue) => setDialog(prev => ({...prev, data: {...prev.data, selectedProvider: newValue}}))}
+                            ListboxProps={{ onScroll: handleProvidersScroll }}
+                            loading={providers.status === 'loading'}
+                            renderInput={(params) => <TextField {...params} label="Provider" margin="dense" fullWidth required />}
+                            isOptionEqualToValue={(option, value) => option.id === value.id}
+                        />
+                    )}
                 </DialogContent>
                 <DialogActions>
                     <Button onClick={handleCloseDialog}>Cancel</Button>


### PR DESCRIPTION
- Configured default parameters on fetchProviders in dataCacheSlice.js to prevent any TypeError when called without arguments.
- Extended the approveUserApplication endpoint wrapper in userApplicationApi.js to transmit the provider ID as a query parameter.
- Enhanced PendingRequests.js to:
  1. Load provider data with standard page/pageSize values.
  2. Implement provider infinite-scrolling dropdown selection using mergedProviders and handleProvidersScroll.
  3. Dynamically show the Provider dropdown if the provider role is chosen.
  4. Auto-initialize the provider selection to the applicant's existing request provider.
  5. Add validation so the provider role cannot be approved without a provider group selection.