### PR TITLE
API Keys Access Control & UI Fixes

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -40,7 +40,7 @@ export const config = {
     ...envConfig,
 
     // Static settings that are the same across all environments
-    version: "0.0.53",
+    version: "0.0.54",
     keycloakRealm: "cue",
 };
 

--- a/src/pages/DAAC.js
+++ b/src/pages/DAAC.js
@@ -197,11 +197,11 @@ export default function DAAC() {
 
     const folderStructurePreview = useMemo(() => {
         let bucket = "<bucket-name>";
-        let destination = "<destination-path>";
+        let destination = "<destination_path>";
         try {
             const parsed = JSON.parse(dialog.data?.config || "{}");
             if (parsed.bucket) bucket = parsed.bucket;
-            if (parsed['destination-path']) destination = parsed['destination-path'];
+            if (parsed['destination_path']) destination = parsed['destination_path'];
         } catch (e) {
             // fallback
         }
@@ -210,7 +210,7 @@ export default function DAAC() {
         const createCollectionSubfolderValue = dialog.data?.create_collection_subfolder || false;
 
         const parts = [bucket];
-        if (destination && destination !== "<destination-path>") {
+        if (destination && destination !== "<destination_path>") {
             parts.push(destination);
         }
         if (createCollectionSubfolderValue) {

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -149,7 +149,9 @@ export default function Home() {
                 <StatCard title="Collections" value={collections.total} onClick={() => navigate('/collections')} icon={<CollectionsIcon color="action" />} loading={collections.status === 'loading'} />
                 )}
                 <StatCard title="Providers" value={providers.total} onClick={() => navigate('/providers')} icon={<AccountBoxIcon color="action" />} loading={providers.status === 'loading'} />
+                {hasPrivilege("egress:read") && (
                 <StatCard title="Egress" value={egresses.total} onClick={() => navigate('/daac')} icon={<OutputIcon color="action" />} loading={egresses.status === 'loading'} />
+                )}
                 {/*The Users card is now only rendered if the user has the 'user:page' privilege. */}
                 {hasPrivilege("user:page") && (
                     <StatCard title="Users" value={users.total} onClick={() => navigate('/users')} icon={<GroupIcon color="action" />} loading={users.status === 'loading'} />

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -1,29 +1,33 @@
 // src/pages/Profile.js
 
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Outlet, useOutletContext } from 'react-router-dom';
 import Box from '@mui/material/Box';
 
 // Import desired icons from Material-UI
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import VpnKeyIcon from '@mui/icons-material/VpnKey';
-
-const profileMenuItems = [
-    { text: 'Profile Info', path: '/profile', icon: <AccountCircleIcon /> },
-    { text: 'API Keys', path: '/profile/api-keys', icon: <VpnKeyIcon /> },
-];
+import usePrivileges from '../hooks/usePrivileges';
 
 function Profile() {
-    // Define the new, ordered side navigation menu for the profile section
-
-
     const { setMenuItems } = useOutletContext();
+    const { hasPrivilege } = usePrivileges();
+
+    const profileMenuItems = useMemo(() => {
+        const items = [
+            { text: 'Profile Info', path: '/profile', icon: <AccountCircleIcon /> },
+        ];
+        if (hasPrivilege('api-key:read')) {
+            items.push({ text: 'API Keys', path: '/profile/api-keys', icon: <VpnKeyIcon /> });
+        }
+        return items;
+    }, [hasPrivilege]);
 
     useEffect(() => {
         setMenuItems(profileMenuItems);
         // Clean up the menu when the component unmounts
         return () => setMenuItems([]);
-    }, [setMenuItems]);
+    }, [setMenuItems, profileMenuItems]);
 
     return (
         <Box sx={{ flexGrow: 1 }}>

--- a/src/pages/Profile/ApiKeys.js
+++ b/src/pages/Profile/ApiKeys.js
@@ -160,7 +160,9 @@ function ApiKeys() {
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                             <TextField label="Search Keys" variant="outlined" size="small" value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} />
                             <Button variant="contained" startIcon={<AddIcon />} onClick={handleCreateClick} disabled={!hasPrivilege('api-key:create')}>Create API Key</Button>
-                            <Button variant="outlined" startIcon={<SyncLockIcon />} onClick={handleSuspendReactivateClick} disabled={selected.length === 0 || !hasPrivilege('api-key:update')}>Suspend/Reactivate</Button>
+                            {hasPrivilege('api-key:update') && (
+                                <Button variant="outlined" startIcon={<SyncLockIcon />} onClick={handleSuspendReactivateClick} disabled={selected.length === 0 || !hasPrivilege('api-key:update')}>Suspend/Reactivate</Button>
+                            )}
                             <Button variant="contained" color="error" startIcon={<DeleteIcon />} onClick={handleRevokeClick} disabled={selected.length === 0 || !hasPrivilege('api-key:delete')}>Revoke</Button>
                         </Box>
                     </Box>

--- a/src/pages/Profile/ApiKeys.js
+++ b/src/pages/Profile/ApiKeys.js
@@ -43,10 +43,10 @@ function ApiKeys() {
     const [total, setTotal] = useState(0);
 
     const fetchApiKeys = useCallback(async () => {
-        // Guard against running if no group is selected.
-        if (!activeNgroupId) {
+        // Guard against running if no group is selected or if user lacks read privilege.
+        if (!activeNgroupId || !hasPrivilege('api-key:read')) {
             setLoading(false);
-            setApiKeys([]); // Clear keys if no group is active
+            setApiKeys([]);
             return;
         }
         setLoading(true);
@@ -56,27 +56,28 @@ function ApiKeys() {
                 page: page + 1,      // state variable
                 page_size: rowsPerPage,
             });
-            setApiKeys(response.api_keys);
-            setTotal(response.total);
-            setPage(response.page - 1);
+            setApiKeys(response?.api_keys || []);
+            setTotal(response?.total || 0);
+            if (response?.page) setPage(response.page - 1);
         } catch (err) {
+            setApiKeys([]);
             toast.error(parseApiError(err));
         } finally {
             setLoading(false);
         }
-    // Added activeNgroupId to the dependency array.
-    }, [activeNgroupId, page, rowsPerPage]);
+    }, [activeNgroupId, page, rowsPerPage, hasPrivilege]);
 
     useEffect(() => {
         fetchApiKeys();
     }, [fetchApiKeys]);
 
     const filteredAndSortedKeys = useMemo(() => {
-        const filtered = apiKeys.filter(key =>
-            key.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-            (key.key_type && key.key_type.toLowerCase().includes(searchTerm.toLowerCase())) ||
-            (key.user_name && key.user_name.toLowerCase().includes(searchTerm.toLowerCase())) ||
-            (key.proxy_user_name && key.proxy_user_name.toLowerCase().includes(searchTerm.toLowerCase()))
+        const safeKeys = Array.isArray(apiKeys) ? apiKeys : [];
+        const filtered = safeKeys.filter(key =>
+            (key?.name || '').toLowerCase().includes(searchTerm.toLowerCase()) ||
+            (key?.key_type || '').toLowerCase().includes(searchTerm.toLowerCase()) ||
+            (key?.user_name || '').toLowerCase().includes(searchTerm.toLowerCase()) ||
+            (key?.proxy_user_name || '').toLowerCase().includes(searchTerm.toLowerCase())
         );
         const comparator = (a, b) => {
             const isAsc = order === 'asc';
@@ -150,6 +151,18 @@ function ApiKeys() {
             setIsSubmitting(false);
         }
     };
+
+    if (!hasPrivilege('api-key:read')) {
+        return (
+            <Card>
+                <CardContent sx={{ textAlign: 'center', py: 5 }}>
+                    <Typography variant="h6" color="text.secondary">
+                        You do not have permission to view or manage API keys.
+                    </Typography>
+                </CardContent>
+            </Card>
+        );
+    }
 
     return (
         <>

--- a/src/pages/Profile/CreateApiKeyModal.js
+++ b/src/pages/Profile/CreateApiKeyModal.js
@@ -15,6 +15,7 @@ import usePrivileges from '../../hooks/usePrivileges';
 import { createApiKey } from '../../api/apiKeys';
 import { listCueusers } from '../../api/cueUser';
 import { parseApiError } from '../../utils/errorUtils';
+import { canCreateApiKeyForOthers } from '../../utils/permissionUtils';
 
 export default function CreateApiKeyModal({ open, onClose, onKeyCreated }) {
   const [keyName, setKeyName] = React.useState('');
@@ -41,17 +42,19 @@ export default function CreateApiKeyModal({ open, onClose, onKeyCreated }) {
   });
 
   const { hasPrivilege } = usePrivileges();
-  const { activeNgroupId } = useAuth(); 
+  const { activeNgroupId, user } = useAuth(); 
+
+  const canCreateForOtherUser = canCreateApiKeyForOthers(user, hasPrivilege);
 
   const maxDate = new Date();
   maxDate.setDate(maxDate.getDate() + 90);
 
   React.useEffect(() => {
-    if (open && hasPrivilege('api-key:create')) {
+    if (open && canCreateForOtherUser) {
       setIsUsersLoading(true);
       fetchUsersPage(usersPage);
     }
-  }, [open, hasPrivilege]);
+  }, [open, canCreateForOtherUser]);
 
   const fetchUsersPage = async (pageNumber) => {
     if (fetchedPages.has(pageNumber) || isUsersLoading) return; // guard against duplicates
@@ -167,16 +170,14 @@ export default function CreateApiKeyModal({ open, onClose, onKeyCreated }) {
     toast.success("Key copied to clipboard!");
   };
 
-  const isManager = hasPrivilege('api-key:create');
-
   // --- scope validation to the disabled check ---
   const atLeastOneScopeSelected = Object.values(scopes).some(v => v);
   const isFormInvalid =
     !keyName.trim() ||
     keyName.trim().length < 3 ||
     !activeNgroupId ||
-    (ownerType === 'user' && !selectedUser) ||
-    (ownerType === 'proxy' && !proxyUserName.trim()) ||
+    (canCreateForOtherUser && ownerType === 'user' && !selectedUser) ||
+    (canCreateForOtherUser && ownerType === 'proxy' && !proxyUserName.trim()) ||
     (expirationType === 'custom' && !customExpirationDate) ||
     !atLeastOneScopeSelected; // <-- New validation rule
 
@@ -203,16 +204,16 @@ export default function CreateApiKeyModal({ open, onClose, onKeyCreated }) {
             sx={{ mb: 3 }}
           />
 
-          <FormControl component="fieldset" sx={{ mb: 3 }}>
+          <FormControl component="fieldset" fullWidth sx={{ mb: 3, display: 'flex' }}>
             <FormLabel component="legend">Key Owner</FormLabel>
             <RadioGroup row value={ownerType} onChange={(e) => setOwnerType(e.target.value)}>
               <FormControlLabel value="self" control={<Radio />} label="My Account" />
-              {isManager && <FormControlLabel value="user" control={<Radio />} label="Another CUE User" />}
-              {isManager && <FormControlLabel value="proxy" control={<Radio />} label="An External (Proxy) User" />}
+              {canCreateForOtherUser && <FormControlLabel value="user" control={<Radio />} label="Another CUE User" />}
+              {canCreateForOtherUser && <FormControlLabel value="proxy" control={<Radio />} label="An External (Proxy) User" />}
             </RadioGroup>
           </FormControl>
 
-          {ownerType === 'user' && (
+          {canCreateForOtherUser && ownerType === 'user' && (
             <Autocomplete
               options={users}
               getOptionLabel={(option) => `${option.name} (@${option.cueusername})`}
@@ -242,10 +243,10 @@ export default function CreateApiKeyModal({ open, onClose, onKeyCreated }) {
             />
           )}
           
-          {ownerType === 'proxy' && (
+          {canCreateForOtherUser && ownerType === 'proxy' && (
             <TextField label="Proxy User Name" fullWidth value={proxyUserName} onChange={(e) => setProxyUserName(e.target.value)} sx={{ mb: 3 }} />
           )}
-          <FormControl component="fieldset" sx={{ mb: 3 }}>
+          <FormControl component="fieldset" fullWidth sx={{ mb: 3, display: 'flex' }}>
             <FormLabel component="legend">Expiration</FormLabel>
             <RadioGroup row value={expirationType} onChange={(e) => setExpirationType(e.target.value)}>
               <FormControlLabel value="5" control={<Radio />} label="5 Days" />

--- a/src/pages/Profile/CreateApiKeyModal.js
+++ b/src/pages/Profile/CreateApiKeyModal.js
@@ -64,11 +64,12 @@ export default function CreateApiKeyModal({ open, onClose, onKeyCreated }) {
       const response = await listCueusers(pageNumber, usersPageSize);
       const data = response; // assuming axios
       
+      const fetchedUsers = Array.isArray(data?.users) ? data.users : [];
       setUsers(prev => [
         ...prev,
-        ...data.users.filter(u => !prev.some(pu => pu.id === u.id))
+        ...fetchedUsers.filter(u => !prev.some(pu => pu.id === u.id))
       ]);
-      setUsersTotal(data.total);
+      setUsersTotal(data?.total || 0);
       setUsersPage(pageNumber);
       
       setFetchedPages(prev => new Set(prev).add(pageNumber)); // mark page as fetched

--- a/src/utils/permissionUtils.js
+++ b/src/utils/permissionUtils.js
@@ -97,6 +97,23 @@ export const canManageAllApiKeys = (privileges = []) => {
 };
 
 /**
+ * Checks if a user can create API keys for another user or proxy user.
+ * Users with 'provider' or 'daac_staff' roles are restricted to creating keys only for themselves.
+ * @param {Object} user - The user object containing roles and privileges.
+ * @param {Function} hasPrivilege - Privilege checking function.
+ * @returns {boolean}
+ */
+export const canCreateApiKeyForOthers = (user, hasPrivilege) => {
+    if (!hasPrivilege || !hasPrivilege('api-key:create')) {
+        return false;
+    }
+    const userRoles = (user?.roles || []).map(r => (typeof r === 'string' ? r.toLowerCase().replace(/\s+/g, '_') : r));
+    const isRestricted = userRoles.includes('provider') || userRoles.includes('daac_observer');
+    return !isRestricted;
+};
+
+
+/**
  * Checks for special security-related privileges.
  * @param {string[]} privileges - The user's list of privileges.
  * @returns {boolean}


### PR DESCRIPTION
Key Changes

- Creation Restrictions: Restricted provider and daac_observer users to creating keys for themselves only (hides "Another CUE User", "Proxy User", and user dropdown in CreateApiKeyModal.js).
- Layout Fix: Fixed line-wrapping issue by setting fullWidth on Key Owner and Expiration form sections.
- Navigation & RBAC: Hidden "API Keys" sidebar link for users without api-key:read and hid action buttons without api-key:update.
- Bug Fix: Added fallback empty arrays (response?.api_keys || []) in ApiKeys.js to fix TypeError: Cannot read properties of undefined (reading 'filter').

Modified Files

- src/utils/permissionUtils.js: Added canCreateApiKeyForOthers helper.
- src/pages/Profile/CreateApiKeyModal.js: Enforced role checks, layout styling, and response guards.
- src/pages/Profile/ApiKeys.js: Added privilege checks, error fallbacks, and conditional button rendering.
- src/pages/Profile.js: Conditionally rendered "API Keys" navigation item.